### PR TITLE
FUNC-008: gpt-5.4-mini(400K) 컨텍스트 윈도우 반영 및 MAX_CONTEXT_TOKENS 조정 (#54)

### DIFF
--- a/src/utils/config.py
+++ b/src/utils/config.py
@@ -25,10 +25,10 @@ SEARCH_TIMEOUT_SECONDS: int = 5
 EMBEDDING_MODEL: str = "text-embedding-3-small"
 EMBEDDING_DIM: int = 1536   # OpenAI 임베딩 모델의 벡터 차원 수
 
-# gpt-5.4-mini 컨텍스트 윈도우(128K) 중 컨텍스트 입력에 할당할 안전 한도
+# gpt-5.4-mini 컨텍스트 윈도우(400K) 중 컨텍스트 입력에 할당할 안전 한도
 # o200k_base 토크나이저 기준 한국어 ~0.5 토큰/글자 (즉 1 토큰 ≈ 2~3 글자)
-# 128K - 최대 출력(16,384) - 시스템 프롬프트/쿼리 여유 ≈ 105,000 으로 설정
-MAX_CONTEXT_TOKENS: int = 105000
+# 400K - 최대 출력(128K) - 시스템 프롬프트/쿼리 여유 ≈ 270,000 으로 설정
+MAX_CONTEXT_TOKENS: int = 270000
 
 # 검색 대상 테이블명 — RetrievedChunk 스키마와 컬럼명을 통일
 CHUNKS_TABLE: str = "chunks"


### PR DESCRIPTION
## 개요

FUNC-008 답변 생성 노드의 컨텍스트 길이 한도를 실제 적용 모델인 `gpt-5.4-mini` 스펙에 맞게 정정합니다. 기존 설계는 `gpt-4o-mini`(128K)를 가정했으나, 실제 모델은 `gpt-5.4-mini`(400K)로 변경되어 컨텍스트 윈도우 관련 상수 및 주석이 모델 스펙과 불일치한 상태였습니다.

---

## 변경 사항

### 수정

- **`src/utils/config.py`** — `MAX_CONTEXT_TOKENS` 값 및 주석을 `gpt-5.4-mini`(400K) 스펙에 맞게 정정
  - `MAX_CONTEXT_TOKENS`: `105,000` → `270,000`
  - 출력 여유분 버퍼: `16,384` → `128,000` (gpt-5.4-mini 최대 출력 한도)
  - 레거시 주석의 `128K` 가정을 실제 `400K` 윈도우 기준으로 전면 정정

---

## 주요 설계 결정

**컨텍스트 한도 산정식**

```text
400K (전체 윈도우)
  - 128K (최대 출력 토큰)
  - 여유분 (시스템 프롬프트 / 쿼리)
  ≈ 270,000 (입력 컨텍스트 할당 한도)
```

입력 최대치(270K)와 출력 최대치(128K)의 합(398K)이 전체 윈도우(400K) 이내에 상주하도록 보장하여 런타임 토큰 초과 오류를 선제적으로 차단합니다.

**토큰 추정 정합성**
`gpt-5.4-mini`는 `o200k_base` 토크나이저를 사용하며 한국어 압축률이 약 0.5 토큰/글자입니다. `generate.py`의 토큰 추정식(`len(context_str) // 2`)이 이 압축률과 일치하므로 별도 수정 없이 신규 한도 값과 정합함을 확인했습니다.

---

## 체크리스트

- [x] 단위 테스트 전체 통과 (`tests/unit/agent/test_generate.py` 15/15)
- [x] `MAX_CONTEXT_TOKENS` 값과 주석이 `gpt-5.4-mini`(400K) 스펙과 일치
- [x] 입력(270K) + 출력(128K) 합산이 전체 윈도우(400K) 이내 보장
- [x] `generate.py` 토큰 추정식(`// 2`)과의 정합성 검토 완료

---

Closes #54