### PR TITLE
feat: rewrite 직후 비회계 조기 종료 라우팅 및 조건부 HIL 도입 (#78, #79)

### DIFF
--- a/src/agent/nodes/rewrite.py
+++ b/src/agent/nodes/rewrite.py
@@ -38,15 +38,17 @@ def _standard_context(standard_filter: str) -> str:
     return _STANDARD_LABEL.get(standard_filter, _STANDARD_LABEL["ALL"])
 
 
-def _strip_markdown(content: str) -> str:
+def _strip_markdown(content: str | None) -> str:
+    if content is None:
+        return ""
     # LLM이 JSON을 마크다운 코드 블록(```json ... ```)으로 감싸 반환하는 경우 래퍼 제거
     # (?:json)? — "json" 언어 태그가 있어도 없어도 매칭 (```json / ``` 둘 다 처리)
     # (?:...) 는 비캡처 그룹으로, re.sub이 매칭된 전체(```json 포함)를 빈 문자열로 교체
     return re.sub(r"^```(?:json)?\s*|\s*```$", "", content.strip())
 
 
-def classify_and_select(query: str) -> tuple[bool, str]:
-    """회계 여부와 검색 전략을 단일 LLM 호출로 판단한다. 실패 시 (True, 'hyde')로 폴백."""
+def classify_and_select(query: str) -> tuple[bool, str, float]:
+    """회계 여부·검색 전략·분류 신뢰도를 단일 LLM 호출로 판단한다. 실패 시 (True, 'hyde', 0.0)로 폴백."""
     try:
         resp = client.chat.completions.create(
             model=OPENAI_MODEL,
@@ -54,16 +56,27 @@ def classify_and_select(query: str) -> tuple[bool, str]:
             response_format={"type": "json_object"},
             temperature=0,
         )
-        data = json.loads(_strip_markdown(resp.choices[0].message.content))
+        data = json.loads(_strip_markdown(resp.choices[0].message.content)) # LLM의 json 출력물을 딕셔너리로 변환
         raw = data.get("is_accounting", True)
         # LLM이 boolean 대신 문자열 "True"/"False"를 반환하는 경우 명시적 변환
         # str(raw).lower() == "true" → "true"면 True, 아니면 False 반환
         is_accounting = raw if isinstance(raw, bool) else str(raw).lower() == "true"
         strategy = data.get("strategy", "hyde")
-        return is_accounting, strategy
+        # LLM이 보고한 분류 신뢰도. 비회계 조기 종료 시 FinalResponse.confidence_score로 전달되어
+        # 운영 단계에서 분류 경계가 모호한(낮은 신뢰도) 케이스를 추출·분석하는 데 활용된다.
+        confidence = _coerce_confidence(data.get("confidence"))
+        return is_accounting, strategy, confidence
     except Exception:
         # !TODO: logger 구현 후 LLM 호출 실패 경고 로그 기록 (예: logger.warning("classify_and_select failed: %s", e))
-        return True, "hyde"
+        return True, "hyde", 0.0
+
+
+def _coerce_confidence(raw) -> float:
+    """LLM이 반환한 confidence 값을 0.0~1.0 범위의 float로 안전하게 변환한다. 실패 시 0.0."""
+    try:
+        return min(1.0, max(0.0, float(raw)))
+    except (TypeError, ValueError):
+        return 0.0
 
 
 def apply_hyde(query: str, standard_filter: str) -> list[str]:
@@ -140,8 +153,9 @@ def rewrite_query(state: GraphState) -> GraphState:
     #        - 전략 교체 여부: 동일 전략 재시도 vs. hyde→decompose→stepback 순 에스컬레이션
     #        - rewrite_count 증가 시점: 이 함수 진입 직후 state.rewrite_count += 1
     try:
-        is_accounting, strategy = classify_and_select(state.original_query)
+        is_accounting, strategy, confidence = classify_and_select(state.original_query)
         state.is_accounting_query = is_accounting
+        state.classification_confidence = confidence
 
         if not is_accounting:
             state.rewritten_query = RewrittenQuery(

--- a/src/agent/nodes/rewrite.py
+++ b/src/agent/nodes/rewrite.py
@@ -79,14 +79,24 @@ def _coerce_confidence(raw) -> float:
         return 0.0
 
 
-def apply_hyde(query: str, standard_filter: str) -> list[str]:
+def _feedback_clause(feedback: str | None) -> str:
+    """HIL 사용자 피드백을 프롬프트에 덧붙일 제약 문구로 변환한다. 피드백이 없으면 빈 문자열."""
+    if not feedback:
+        return ""
+    return (
+        f"\n\n[사용자 추가 요청]\n{feedback}\n"
+        "위 추가 요청을 반드시 반영하여 작성하세요."
+    )
+
+
+def apply_hyde(query: str, standard_filter: str, feedback: str | None = None) -> list[str]:
     """원문 + 가상 답변을 반환한다. LLM 실패 시 원문만 반환."""
     try:
         resp = client.chat.completions.create(
             model=OPENAI_MODEL,
             messages=[{"role": "user", "content": HYDE_PROMPT.format(
                 query=query, standard_context=_standard_context(standard_filter)
-            )}],
+            ) + _feedback_clause(feedback)}],
             response_format={"type": "json_object"},
             temperature=0,
         )
@@ -99,14 +109,14 @@ def apply_hyde(query: str, standard_filter: str) -> list[str]:
     return [query]
 
 
-def apply_decompose(query: str, standard_filter: str) -> list[str]:
+def apply_decompose(query: str, standard_filter: str, feedback: str | None = None) -> list[str]:
     """원문 + 서브쿼리들을 반환한다. LLM 실패 시 원문만 반환."""
     try:
         resp = client.chat.completions.create(
             model=OPENAI_MODEL,
             messages=[{"role": "user", "content": DECOMPOSE_PROMPT.format(
                 query=query, standard_context=_standard_context(standard_filter)
-            )}],
+            ) + _feedback_clause(feedback)}],
             response_format={"type": "json_object"},
             temperature=0,
         )
@@ -119,14 +129,14 @@ def apply_decompose(query: str, standard_filter: str) -> list[str]:
     return [query]
 
 
-def apply_stepback(query: str, standard_filter: str) -> list[str]:
+def apply_stepback(query: str, standard_filter: str, feedback: str | None = None) -> list[str]:
     """원문 + 추상화된 원칙 쿼리를 반환한다. LLM 실패 시 원문만 반환."""
     try:
         resp = client.chat.completions.create(
             model=OPENAI_MODEL,
             messages=[{"role": "user", "content": STEPBACK_PROMPT.format(
                 query=query, standard_context=_standard_context(standard_filter)
-            )}],
+            ) + _feedback_clause(feedback)}],
             response_format={"type": "json_object"},
             temperature=0,
         )
@@ -152,6 +162,12 @@ def rewrite_query(state: GraphState) -> GraphState:
     #        - classify_and_select는 재호출 불필요 (질의·is_accounting 불변) → state 값 재사용
     #        - 전략 교체 여부: 동일 전략 재시도 vs. hyde→decompose→stepback 순 에스컬레이션
     #        - rewrite_count 증가 시점: 이 함수 진입 직후 state.rewrite_count += 1
+
+    # HIL 루프에서 주입된 사용자 피드백을 사용 즉시 회수·초기화한다.
+    # (다음 CRAG/HIL 루프에서 이전 피드백이 잘못 재사용되는 것을 방지)
+    feedback = state.human_feedback
+    state.human_feedback = None
+
     try:
         is_accounting, strategy, confidence = classify_and_select(state.original_query)
         state.is_accounting_query = is_accounting
@@ -165,7 +181,7 @@ def rewrite_query(state: GraphState) -> GraphState:
             )
             return state
 
-        queries = _STRATEGY_FN[strategy](state.original_query, state.standard_filter)
+        queries = _STRATEGY_FN[strategy](state.original_query, state.standard_filter, feedback)
         state.rewritten_query = RewrittenQuery(
             original_query=state.original_query,
             strategy=strategy,

--- a/src/agent/prompts.py
+++ b/src/agent/prompts.py
@@ -46,7 +46,11 @@ CLASSIFY_STRATEGY_PROMPT: str = """당신은 사용자 질의를 분석하여 �
 질의: {query}
 
 반드시 JSON으로만 답하세요:
-{{"is_accounting": true | false, "strategy": "hyde" | "decompose" | "stepback" | "bypass"}}
+{{"is_accounting": true | false, "strategy": "hyde" | "decompose" | "stepback" | "bypass", "confidence": 0.0 ~ 1.0}}
+
+[confidence 작성 규칙]
+- is_accounting 판단(회계/비회계 분류)에 대한 스스로의 확신 정도를 0.0~1.0으로 기록합니다.
+- 명백하게 회계/비회계로 구분되는 질의는 1.0에 가깝게, 경계가 모호한 질의는 0.5~0.7 수준으로 보수적으로 기록합니다.
 
 [is_accounting 판단 기준]
 회계 관련 (true):

--- a/src/agent/workflow.py
+++ b/src/agent/workflow.py
@@ -77,8 +77,40 @@ def rewrite(state: GraphState) -> dict:
         "rewrite_count": updated_state.rewrite_count,
         "rewritten_query": updated_state.rewritten_query,
         "is_accounting_query": updated_state.is_accounting_query,
+        "classification_confidence": updated_state.classification_confidence,
         "error_logs": updated_state.error_logs,
     }
+
+
+def early_exit(state: GraphState) -> dict:
+    """
+    비회계 질문 조기 종료 노드.
+
+    route_after_rewrite가 비회계 질의로 분기시킨 경우 검색·재정렬·평가·생성 파이프라인을
+    건너뛰고 안내 메시지를 담은 FinalResponse를 생성한 뒤 END로 종료한다.
+    confidence_score에는 rewrite 노드가 기록한 LLM 분류 신뢰도를 그대로 전달하여,
+    운영 단계에서 분류 경계가 모호한 케이스를 추출·분석할 수 있도록 한다.
+    """
+    return {
+        "final_response": FinalResponse(
+            answer="죄송합니다. 회계 관련 질문을 해 주세요.",
+            citations=[],
+            is_answerable=False,
+            confidence_score=state.classification_confidence,
+        )
+    }
+
+
+def route_after_rewrite(state: GraphState) -> Literal["early_exit", "search"]:
+    """
+    rewrite 노드 직후 분기 결정.
+
+    - 비회계 질의(is_accounting_query=False): early_exit 노드로 분기하여 안내 응답 후 종료.
+    - 회계 질의: 정상적으로 search 노드로 진행.
+    """
+    if not state.is_accounting_query:
+        return "early_exit"
+    return "search"
 
 def search(state: GraphState) -> dict:
     """하이브리드 검색 노드 — searcher.search_chunks() 호출"""
@@ -261,8 +293,9 @@ def build_workflow() -> CompiledStateGraph:
     LangGraph StateGraph를 구성하고 컴파일하여 반환합니다.
 
     노드 등록 및 조건부 엣지를 정의하여 StateGraph를 반환한다.
-    실행 순서: rewrite → search → rerank → evaluate → generate
-    evaluate 이후 route_after_evaluate로 분기 처리.
+    실행 순서: rewrite → (회계 질의) search → rerank → evaluate → generate
+                       → (비회계 질의) early_exit → END
+    rewrite 이후 route_after_rewrite로, evaluate 이후 route_after_evaluate로 분기 처리.
 
     return CompiledStateGraph : LangGraph로 빌드된 상태 그래프
     왜 CompiledGraph를 사용하는가? -> StateGraph보다 성능이 좋다. (동작 방식은 동일하지만 내부적으로 최적화됨)
@@ -273,6 +306,7 @@ def build_workflow() -> CompiledStateGraph:
 
     # 노드 추가
     workflow.add_node("rewrite", rewrite)
+    workflow.add_node("early_exit", early_exit)
     workflow.add_node("search", search)
     workflow.add_node("rerank", rerank)
     workflow.add_node("evaluate", evaluate)
@@ -280,7 +314,18 @@ def build_workflow() -> CompiledStateGraph:
 
     # 엣지 연결 (고정 흐름)
     workflow.add_edge(START, "rewrite")
-    workflow.add_edge("rewrite", "search")
+
+    # rewrite 직후 조건부 분기: 비회계 질의는 early_exit로 조기 종료, 회계 질의는 search로 진행
+    workflow.add_conditional_edges(
+        "rewrite",
+        route_after_rewrite,
+        {
+            "early_exit": "early_exit",
+            "search": "search",
+        }
+    )
+    workflow.add_edge("early_exit", END)
+
     workflow.add_edge("search", "rerank")
     workflow.add_edge("rerank", "evaluate")
 

--- a/src/agent/workflow.py
+++ b/src/agent/workflow.py
@@ -1,17 +1,22 @@
 # FUNC-009: LangGraph StateGraph 파이프라인 정의
 
+import uuid
 from datetime import datetime
 from functools import wraps
 from typing import Any, Literal
+from langchain_core.runnables import RunnableConfig
 from langgraph.errors import GraphRecursionError
 from langgraph.graph import StateGraph, START, END
 from langgraph.graph.state import CompiledStateGraph
+from langgraph.checkpoint.base import BaseCheckpointSaver
+from langgraph.checkpoint.memory import MemorySaver
+from langgraph.types import interrupt, Command
 from src.agent.nodes.generate import generate_response as generate
 from src.agent.nodes.evaluate import evaluate_context as evaluate
 from src.retrieval.searcher import search_chunks as _search_impl
 from src.retrieval.reranker import rerank_chunks as _rerank_impl
 from src.utils import config
-from src.utils.config import MAX_REWRITE_COUNT, KST, RERANK_THRESHOLD, TOP_K_RETRIEVAL
+from src.utils.config import MAX_REWRITE_COUNT, MAX_HIL_COUNT, KST, RERANK_THRESHOLD, TOP_K_RETRIEVAL
 from src.utils.exception import (
     AccountingRAGError,
     RerankFailureError,
@@ -64,10 +69,12 @@ def rewrite(state: GraphState) -> dict:
     """
     질의 재작성 노드 연결
     """
-    # 주의: 래퍼에서 rewrite_count를 증가시키므로, 
-    # _rewrite_impl 내부에서는 카운트를 증가시키지 않아야 한다는 계약을 유지합니다.
-    state.rewrite_count += 1
-    
+    # 주의: 래퍼에서 rewrite_count를 증가시키므로, _rewrite_impl 내부에서는 카운트를 증가시키지 않아야 한다는 계약을 유지합니다.
+    # 단, HIL 피드백으로 인한 재진입(human_feedback 존재)은 CRAG 재시도가 아니므로
+    # rewrite_count를 증가시키지 않는다. (CRAG 루프=rewrite_count, HIL 루프=hil_count로 분리)
+    if not state.human_feedback:
+        state.rewrite_count += 1
+
     # 실제 모듈을 통해 상태 변화 수행 (in-place mutation)
     # updated_state는 사실상 state와 동일한 객체입니다.
     updated_state = _rewrite_impl(state)
@@ -78,6 +85,9 @@ def rewrite(state: GraphState) -> dict:
         "rewritten_query": updated_state.rewritten_query,
         "is_accounting_query": updated_state.is_accounting_query,
         "classification_confidence": updated_state.classification_confidence,
+        # rewrite_query가 사용 후 None으로 초기화한 값을 반드시 채널에 반영해야
+        # route_after_human_review가 다음 루프에서 잘못 rewrite로 분기하지 않는다.
+        "human_feedback": updated_state.human_feedback,
         "error_logs": updated_state.error_logs,
     }
 
@@ -101,15 +111,80 @@ def early_exit(state: GraphState) -> dict:
     }
 
 
-def route_after_rewrite(state: GraphState) -> Literal["early_exit", "search"]:
+def route_after_rewrite(state: GraphState) -> Literal["early_exit", "human_review"]:
     """
     rewrite 노드 직후 분기 결정.
 
     - 비회계 질의(is_accounting_query=False): early_exit 노드로 분기하여 안내 응답 후 종료.
-    - 회계 질의: 정상적으로 search 노드로 진행.
+    - 회계 질의: human_review 노드로 진행한다. (HIL 적용 여부는 human_review 노드가 전략 기반으로 결정)
     """
     if not state.is_accounting_query:
         return "early_exit"
+    return "human_review"
+
+
+# 조건부 HIL 트리거 전략: 복잡하거나 추상화가 필요해 사용자 확인 가치가 큰 전략만 중단한다.
+# 단순 hyde 전략은 중단 없이 search로 통과시킨다. (운영 데이터 축적 후 confidence 기반 조건 추가 검토)
+HIL_STRATEGIES: set[str] = {"decompose", "stepback"}
+
+
+def human_review(state: GraphState) -> dict:
+    """
+    조건부 Human-in-the-Loop 노드.
+
+    재작성 전략이 HIL_STRATEGIES(decompose/stepback)에 해당하고, 아직 승인되지 않았으며,
+    HIL 재작성 횟수가 MAX_HIL_COUNT 미만일 때에만 interrupt()로 워크플로우를 중단하여
+    사용자 확인을 받는다. 그 외(단순 hyde 전략·이미 승인·최대 횟수 도달)는 중단 없이 통과한다.
+
+    interrupt() 페이로드에는 구조화된 선택지(options)를 포함해 클라이언트가 UI로 렌더링하도록 한다.
+    재개 시 주입되는 값의 action에 따라 분기한다.
+      - action="rewrite": human_feedback 저장 + hil_count 증가 → route_after_human_review가 rewrite로 루프백
+      - 그 외(approve 등): human_approved=True 설정 → search로 진행
+    """
+    strategy = state.rewritten_query.strategy if state.rewritten_query else "hyde"
+
+    should_review = (
+        strategy in HIL_STRATEGIES
+        and not state.human_approved
+        and state.hil_count < MAX_HIL_COUNT
+    )
+    if not should_review:
+        # 통과: 상태 변경 없음
+        return {}
+
+    # interrupt: 워크플로우를 중단하고 사용자 확인을 받음
+    decision = interrupt({
+        "type": "human_review",
+        "strategy": strategy,
+        "original_query": state.original_query,
+        "search_queries": state.rewritten_query.search_queries if state.rewritten_query else [],
+        "hil_count": state.hil_count,
+        "max_hil_count": MAX_HIL_COUNT,
+        "options": [
+            {"action": "approve", "label": "이대로 검색을 진행합니다"},
+            {"action": "rewrite", "label": "재작성을 요청합니다 (피드백 입력)"},
+        ],
+    })
+
+    decision = decision or {}   # decision이 None이면 빈 딕셔너리로 초기화
+    if decision.get("action") == "rewrite":
+        return {
+            "human_feedback": decision.get("feedback", ""),
+            "hil_count": state.hil_count + 1,
+        }
+    # approve(기본): 현재 재작성 결과를 승인 처리
+    return {"human_approved": True}
+
+
+def route_after_human_review(state: GraphState) -> Literal["rewrite", "search"]:
+    """
+    human_review 노드 직후 분기 결정.
+
+    - human_feedback이 존재하면 사용자가 재작성을 요청한 것 → rewrite로 루프백.
+    - 그 외(승인 또는 통과)는 search로 진행.
+    """
+    if state.human_feedback:
+        return "rewrite"
     return "search"
 
 def search(state: GraphState) -> dict:
@@ -288,14 +363,20 @@ def route_after_evaluate(state: GraphState) -> str:
     # 검색된 컨텍스트가 충분히 유효하거나(needs_external=False), 이미 최대 재시도 횟수를 소진했다면 답변을 생성합니다.
     return "generate"
 
-def build_workflow() -> CompiledStateGraph:
+def build_workflow(checkpointer: BaseCheckpointSaver | None = None) -> CompiledStateGraph:
     """
     LangGraph StateGraph를 구성하고 컴파일하여 반환합니다.
 
     노드 등록 및 조건부 엣지를 정의하여 StateGraph를 반환한다.
-    실행 순서: rewrite → (회계 질의) search → rerank → evaluate → generate
+    실행 순서: rewrite → (회계 질의) human_review → search → rerank → evaluate → generate
                        → (비회계 질의) early_exit → END
-    rewrite 이후 route_after_rewrite로, evaluate 이후 route_after_evaluate로 분기 처리.
+    rewrite 이후 route_after_rewrite, human_review 이후 route_after_human_review,
+    evaluate 이후 route_after_evaluate로 분기 처리.
+
+    Args:
+        checkpointer: HIL(interrupt/resume)을 위한 상태 저장소.
+        None이면 체크포인트 없이 컴파일되며 interrupt()를 호출할 수 없다(단순 단방향 실행 전용).
+        HIL을 사용하는 run_workflow/resume_workflow는 MemorySaver 싱글턴(_CHECKPOINTER)을 주입한다.
 
     return CompiledStateGraph : LangGraph로 빌드된 상태 그래프
     왜 CompiledGraph를 사용하는가? -> StateGraph보다 성능이 좋다. (동작 방식은 동일하지만 내부적으로 최적화됨)
@@ -307,6 +388,7 @@ def build_workflow() -> CompiledStateGraph:
     # 노드 추가
     workflow.add_node("rewrite", rewrite)
     workflow.add_node("early_exit", early_exit)
+    workflow.add_node("human_review", human_review)
     workflow.add_node("search", search)
     workflow.add_node("rerank", rerank)
     workflow.add_node("evaluate", evaluate)
@@ -315,16 +397,26 @@ def build_workflow() -> CompiledStateGraph:
     # 엣지 연결 (고정 흐름)
     workflow.add_edge(START, "rewrite")
 
-    # rewrite 직후 조건부 분기: 비회계 질의는 early_exit로 조기 종료, 회계 질의는 search로 진행
+    # rewrite 직후 조건부 분기: 비회계 질의는 early_exit로 조기 종료, 회계 질의는 human_review로 진행
     workflow.add_conditional_edges(
         "rewrite",
         route_after_rewrite,
         {
             "early_exit": "early_exit",
-            "search": "search",
+            "human_review": "human_review",
         }
     )
     workflow.add_edge("early_exit", END)
+
+    # human_review 직후 조건부 분기: 사용자가 재작성 요청 시 rewrite로 루프백, 아니면 search로 진행
+    workflow.add_conditional_edges(
+        "human_review",
+        route_after_human_review,
+        {
+            "rewrite": "rewrite",
+            "search": "search",
+        }
+    )
 
     workflow.add_edge("search", "rerank")
     workflow.add_edge("rerank", "evaluate")
@@ -341,44 +433,103 @@ def build_workflow() -> CompiledStateGraph:
 
     workflow.add_edge("generate", END)
 
-    # 그래프 컴파일
-    return workflow.compile()
+    # 그래프 컴파일 (checkpointer가 주어지면 HIL interrupt/resume 지원)
+    return workflow.compile(checkpointer=checkpointer)
 
 
-def run_workflow(query: str, standard_filter: Literal["GAAP", "KIFRS", "ALL"] = "ALL") -> dict[str, Any]:
+# HIL(interrupt/resume) 상태를 run_workflow와 resume_workflow 호출 간 공유하기 위한 인메모리 체크포인터 싱글턴
+# MemorySaver는 체크포인트를 자신의 내부 저장소에 thread_id로 보관하므로
+# 매 호출마다 build_workflow로 그래프를 새로 컴파일하더라도 동일 인스턴스를 주입하면 중단된 세션을 정상적으로 재개할 수 있다.
+# !TODO: 실서비스 전환 시 AsyncPostgresSaver로 교체 (checkpointer 인터페이스 통일됨)
+_CHECKPOINTER: BaseCheckpointSaver = MemorySaver()
+
+
+def _run_config(thread_id: str) -> RunnableConfig:
+    """LangGraph invoke에 전달할 실행 설정. thread_id로 HIL 세션을 식별한다."""
+    return {
+        "configurable": {"thread_id": thread_id},
+        "recursion_limit": MAX_REWRITE_COUNT * 5 + 5,
+    }
+
+
+def _recursion_fallback_response() -> FinalResponse:
+    return FinalResponse(
+        answer="너무 많은 재시도가 발생하여 답변을 생성하지 못했습니다. 질문을 구체화하여 다시 시도해주세요.",
+        citations=[],
+        is_answerable=False,
+        confidence_score=0.0,
+    )
+
+
+def run_workflow(
+    query: str,
+    standard_filter: Literal["GAAP", "KIFRS", "ALL"] = "ALL",
+    thread_id: str | None = None,
+) -> dict[str, Any]:
     """
     외부에서 워크플로우를 실행하기 위한 진입점 함수.
+
+    HIL을 지원하기 위해 MemorySaver 체크포인터를 주입하고 thread_id로 세션을 식별한다.
+    thread_id가 주어지지 않으면 새 UUID를 발급한다. 반환 dict에는 항상 thread_id가 포함되어,
+    워크플로우가 human_review에서 중단(`__interrupt__` 키 존재)된 경우 클라이언트가 이 값을
+    resume_workflow에 전달하여 재개할 수 있다.
     """
-    app = build_workflow()
-    
+    app = build_workflow(checkpointer=_CHECKPOINTER)
+
     # 노드별 30초 타임아웃 설정 (LangGraph CompiledStateGraph 속성)
     app.step_timeout = 30
-    
+
+    if thread_id is None:
+        thread_id = str(uuid.uuid4())
+
     initial_state = GraphState(original_query=query, standard_filter=standard_filter)
-    
+
     try:
-        # 정상 반환 시 LangGraph의 invoke()는 dict를 반환하며 값들은 Pydantic 객체를 유지합니다.
-        return app.invoke(
-            initial_state, 
-            config={
-                "recursion_limit": MAX_REWRITE_COUNT * 5 + 5
-            }
-        )
+        # 정상/중단 반환 시 LangGraph의 invoke()는 dict를 반환하며 값들은 Pydantic 객체를 유지합니다.
+        # human_review에서 interrupt가 발생하면 반환 dict에 "__interrupt__" 키가 포함됩니다.
+        result = app.invoke(initial_state, config=_run_config(thread_id))
+        result["thread_id"] = thread_id
+        return result
     except GraphRecursionError:
         # GraphRecursionError 발생 시 최선 답변 혹은 답변 불가 상태 반환
-        initial_state.final_response = FinalResponse(
-            answer="너무 많은 재시도가 발생하여 답변을 생성하지 못했습니다. 질문을 구체화하여 다시 시도해주세요.",
-            citations=[],
-            is_answerable=False,
-            confidence_score=0.0
-        )
-        # TODO: 예외 발생 시 error_logs 기록 및 우아한(graceful) 상태 반환 로직 정교화
-        # invoke() 결과와 동일한 직렬화 구조 유지를 위해, model_dump() 대신 
+        initial_state.final_response = _recursion_fallback_response()
+        # TODO: 예외 발생 시 error_logs 기록 및 상태 반환 로직 정교화
+        # invoke() 결과와 동일한 직렬화 구조 유지를 위해, model_dump() 대신
         # Pydantic 인스턴스를 값으로 유지하는 dict comprehension 방식을 사용합니다.
-        return {k: getattr(initial_state, k) for k in GraphState.model_fields}  # {<'original_query': QueryObject>, <'standard_filter': 'ALL'>, ...}
+        fallback = {k: getattr(initial_state, k) for k in GraphState.model_fields}  # 예시: {'original_query': '....', ...}
+        fallback["thread_id"] = thread_id
+        return fallback
     except TimeoutError:
         # 타임아웃 발생 시
-        # TODO: MVP 단계에서는 타임아웃 발생 시 호출자(API 라우터 등)가 예외를 처리하도록 재전파(re-raise)합니다. 
+        # TODO: MVP 단계에서는 타임아웃 발생 시 호출자(API 라우터 등)가 예외를 처리하도록 재전파(re-raise)합니다.
         # 추후 타임아웃 발생 시 안전한 GraphState 반환 및 error_logs 기록 로직 추가 필요.
         # traceback을 보존하기 위해 인수 없이 raise를 사용합니다.
+        raise
+
+
+def resume_workflow(thread_id: str, resume_value: dict[str, Any]) -> dict[str, Any]:
+    """
+    human_review에서 interrupt로 중단된 워크플로우를 재개한다.
+
+    thread_id로 체크포인터에 보관된 중간 상태를 복원하고, resume_value를 human_review 노드의 interrupt() 반환값으로 주입하여 실행을 이어간다.
+    resume_value는 구조화된 결정 dict이며, 예: {"action": "approve"} 또는 {"action": "rewrite", "feedback": "리스 회계처리를 강조해줘"}.
+
+    반환 dict에는 thread_id가 포함된다. 사용자가 다시 재작성을 요청하여 또 한 번 중단되면
+    반환 dict에 "__interrupt__" 키가 존재하므로, 동일 thread_id로 재차 resume_workflow를 호출한다.
+    """
+    app = build_workflow(checkpointer=_CHECKPOINTER)
+    app.step_timeout = 30
+
+    try:
+        result = app.invoke(Command(resume=resume_value), config=_run_config(thread_id))
+        result["thread_id"] = thread_id
+        return result
+    except GraphRecursionError:
+        # 재개 시점에는 initial_state가 없으므로 체크포인트에 보관된 현재 상태를 복원해 폴백을 구성한다.
+        snapshot = app.get_state(_run_config(thread_id))
+        fallback = dict(snapshot.values)
+        fallback["final_response"] = _recursion_fallback_response()
+        fallback["thread_id"] = thread_id
+        return fallback
+    except TimeoutError:
         raise

--- a/src/models/state.py
+++ b/src/models/state.py
@@ -25,7 +25,8 @@ class GraphState(BaseModel):
     standard_filter:      Literal["GAAP", "KIFRS", "ALL"] = "ALL"  # UI에서 사용자가 선택한 기준서 범위
 
     # 의도 분류
-    is_accounting_query:  bool                   = True   # 회계 질의 여부. 비회계면 rewrite 노드에서 Bypass
+    is_accounting_query:  bool                   = True   # 회계 질의 여부. 비회계면 route_after_rewrite가 early_exit로 분기
+    classification_confidence: float             = 0.0    # [rewrite 노드] LLM이 보고한 회계/비회계 분류 신뢰도(0.0~1.0). early_exit가 FinalResponse.confidence_score로 전달
 
     # 질의 재작성 및 검색 관련
     # !TODO: 평가 임계치 미달로 CRAG 루프를 통해 재진입할 때 rewrite_query가 동일 전략을 반복할지, 전략을 교체할지(예: hyde→decompose→stepback) 결정 필요.

--- a/src/models/state.py
+++ b/src/models/state.py
@@ -34,6 +34,11 @@ class GraphState(BaseModel):
     rewrite_count:        int                    = 0      # [rewrite 노드] CRAG 루프 진입 횟수 기록 (최대 MAX_REWRITE_COUNT)
     rewritten_query:      RewrittenQuery | None  = None   # [rewrite 노드] 검색에 최적화된 새로운 쿼리
 
+    # Human-in-the-Loop (HIL) 관련 — human_review 노드가 interrupt()로 사용자 확인을 받는다
+    human_feedback:       str | None             = None   # [human_review→rewrite] 사용자가 입력한 재작성 요청 사항. rewrite 노드가 프롬프트에 반영 후 초기화
+    human_approved:       bool                   = False  # [human_review 노드] 사용자가 현재 재작성 결과를 승인했는지 여부
+    hil_count:            int                    = 0      # [human_review 노드] HIL 재작성 요청 횟수 (최대 MAX_HIL_COUNT, CRAG 루프와 분리)
+
     # 문서 검색 및 재정렬 관련
     retrieved_chunks:     list[RetrievedChunk]   = []     # [search 노드] DB/벡터 검색된 원본 문서 청크 리스트
     reranked_chunks:      list[RerankingResult]  = []     # [rerank 노드] 쿼리와의 유사도를 기준으로 재정렬 및 필터링된 결과

--- a/src/utils/config.py
+++ b/src/utils/config.py
@@ -1,7 +1,8 @@
 from datetime import timezone, timedelta
 
 # 파이프라인 전역 설정값
-MAX_REWRITE_COUNT: int = 3          # FUNC-004: 질의 재작성 최대 반복 횟수
+MAX_REWRITE_COUNT: int = 3          # FUNC-004: CRAG 루프(평가 임계치 미달 재검색) 최대 반복 횟수
+MAX_HIL_COUNT: int = 5              # 워크플로우: Human-in-the-Loop 재작성 요청 최대 반복 횟수 (CRAG 루프와 분리)
 TOP_K_RETRIEVAL: int = 10           # FUNC-005: 1차 검색 반환 청크 수
 
 # Reranking Configuration

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -1,0 +1,52 @@
+"""
+통합 테스트 공용 헬퍼
+
+Human-in-the-Loop 도입으로 decompose/stepback 전략 질의는 search 이전에 human_review 노드에서 interrupt()로 중단된다.
+단발성 실행을 가정하는 벤치마크/통합 테스트가 이 중단으로 final_response=None을 받는 문제를 막기 위해,
+중단을 자동 승인하여 끝까지 진행시키는 헬퍼를 제공한다.
+"""
+from typing import Any, Literal
+
+from src.agent.workflow import run_workflow, resume_workflow
+
+# 그래프 내부 MAX_HIL_COUNT(=5, #79 결정)보다 1 큰 안전 상한.
+# 그래프가 정상이라면 결코 도달하지 않으며, 무한 루프 회귀 시 즉시 실패하도록 가드한다.
+_MAX_AUTO_APPROVE = 6
+
+
+def run_workflow_to_completion(
+    query: str,
+    *,
+    standard_filter: Literal["GAAP", "KIFRS", "ALL"] = "ALL",
+    **kwargs: Any,
+) -> dict[str, Any]:
+    """HIL 중단을 자동 승인하여 단발성 완료를 보장한다.
+
+    decompose/stepback로 분류되어 human_review에서 interrupt 되더라도 사람 개입 없이 끝까지 진행한 뒤 최종 상태를 반환한다.
+    approve 액션은 사람 피드백을 주입하지 않는 중립 통과이므로, 재작성된 질의를 그대로 search로 넘겨 검색·grounding 측정값을 왜곡하지 않는다.
+
+    Args:
+        query: 사용자 질의.
+        standard_filter: 기준서 범위 필터. run_workflow와 동일 계약.
+        **kwargs: run_workflow로 그대로 전달되는 추가 인자(thread_id 등).
+
+    Returns:
+        interrupt가 모두 소거된 최종 상태 dict (final_response 포함).
+
+    Raises:
+        RuntimeError: auto-approve 횟수가 _MAX_AUTO_APPROVE를 초과한 경우
+            (HIL 루프가 종료되지 않는 회귀를 테스트에서 즉시 검출).
+    """
+    result = run_workflow(query, standard_filter=standard_filter, **kwargs)
+    guard = 0
+    while "__interrupt__" in result:
+        guard += 1
+        if guard > _MAX_AUTO_APPROVE:
+            raise RuntimeError(
+                f"auto-approve 루프 상한({_MAX_AUTO_APPROVE}) 초과 — "
+                f"HIL 루프가 종료되지 않음 (query={query!r})"
+            )
+        thread_id = result.get("thread_id")
+        assert thread_id, "interrupt 상태에 thread_id 가 없음 (#79 계약 위반)"
+        result = resume_workflow(thread_id, {"action": "approve"})
+    return result

--- a/tests/integration/test_benchmark_compliance.py
+++ b/tests/integration/test_benchmark_compliance.py
@@ -13,11 +13,11 @@ import pytest
 from unittest.mock import patch
 
 from tests.utils.benchmark_loader import load_benchmark, BenchmarkCase
+from tests.integration.helpers import run_workflow_to_completion
 from src.models.schemas import (
-    RetrievedChunk, RerankingResult, EvaluationResult, 
+    RetrievedChunk, RerankingResult, EvaluationResult,
     FinalResponse, Citation
 )
-from src.agent.workflow import run_workflow
 
 # ── Benchmark 케이스 로딩 ──
 _BENCHMARK_CASES = load_benchmark()
@@ -38,7 +38,9 @@ class TestBenchmarkCompliance:
         회계 RAG 시스템의 핵심 가치는 '어떤 기준서 조항을 근거로 답했는가'에 있습니다.
         """
         # 실제 워크플로우를 실행하여 결과 획득
-        result = run_workflow(case.query, standard_filter=case.standard)
+        # decompose/stepback 분류 시 human_review에서 interrupt 되므로,
+        # auto-approve 헬퍼로 끝까지 진행시켜 단발성 완료를 보장한다. (#90)
+        result = run_workflow_to_completion(case.query, standard_filter=case.standard)
         response = result.get("final_response")
         assert response is not None, f"[{case.id}] final_response 결과가 존재하지 않습니다."
 
@@ -66,7 +68,9 @@ class TestBenchmarkCompliance:
         Benchmark에 포함된 질의는 모두 회계 기준서에서 답변 가능한 질의입니다.
         """
         # 실제 워크플로우를 실행하여 결과 획득
-        result = run_workflow(case.query, standard_filter=case.standard)
+        # decompose/stepback 분류 시 human_review에서 interrupt 되므로,
+        # auto-approve 헬퍼로 끝까지 진행시켜 단발성 완료를 보장한다. (#90)
+        result = run_workflow_to_completion(case.query, standard_filter=case.standard)
         response = result.get("final_response")
         assert response is not None, f"[{case.id}] final_response 결과가 존재하지 않습니다."
 

--- a/tests/unit/agent/test_hil_workflow.py
+++ b/tests/unit/agent/test_hil_workflow.py
@@ -1,0 +1,238 @@
+import json
+import pytest
+from unittest.mock import MagicMock, patch
+from langgraph.checkpoint.memory import MemorySaver
+from langgraph.types import Command
+
+from src.agent.workflow import (
+    build_workflow,
+    human_review,
+    route_after_human_review,
+    run_workflow,
+    resume_workflow,
+)
+from src.models.state import GraphState
+from src.models.schemas import RetrievedChunk, RewrittenQuery
+from src.utils.config import MAX_HIL_COUNT
+
+# TODO: Fixture를 testconf.py에서 정의할 수 있는지 점검
+
+def _mock_resp(content: dict) -> MagicMock:
+    """OpenAI 응답 객체를 흉내 낸 가짜 객체 생성 (content를 JSON 문자열로 직렬화)"""
+    resp = MagicMock()
+    resp.choices[0].message.content = json.dumps(content)
+    return resp
+
+
+@pytest.fixture(autouse=True)
+def mock_searcher():
+    """외부 DB/API를 호출하는 searcher 모킹 (HIL 통과 후 search 노드 진입 대비)"""
+    with patch("src.agent.workflow._search_impl") as mock_search:
+        mock_search.return_value = [
+            RetrievedChunk(
+                chunk_id="1", document_id="DOC-001",
+                content="유형자산의 감가상각은...", score=0.9, metadata={}
+            ),
+        ]
+        yield mock_search
+
+
+@pytest.fixture
+def hil_app():
+    """HIL(interrupt/resume)을 위해 MemorySaver 체크포인터로 컴파일한 워크플로우"""
+    return build_workflow(checkpointer=MemorySaver())
+
+
+def _decompose_state_query():
+    """rewrite가 decompose 전략으로 분류되도록 강제하는 patch 컨텍스트 헬퍼용 질의"""
+    return "유형자산과 무형자산의 감가상각 방법 차이는?"
+
+
+# ── route_after_human_review 단위 ───────────────────────────────────────────────
+
+@pytest.mark.unit
+class TestRouteAfterHumanReview:
+    def test_feedback_present_routes_to_rewrite(self):
+        state = GraphState(original_query="q", human_feedback="리스를 강조해줘")
+        assert route_after_human_review(state) == "rewrite" # 피드백이 있으면 rewrite 노드로 이동
+
+    def test_no_feedback_routes_to_search(self):
+        state = GraphState(original_query="q", human_feedback=None)
+        assert route_after_human_review(state) == "search" # 피드백이 없으면 search 노드로 이동
+
+
+# ── human_review 노드 단위 (interrupt 없이 통과하는 경로) ────────────────────────
+
+@pytest.mark.unit
+class TestHumanReviewPassThrough:
+    def test_hyde_strategy_passes_through(self):
+        """단순 hyde 전략은 interrupt 없이 빈 dict 반환(통과)"""
+        state = GraphState(
+            original_query="q",
+            rewritten_query=RewrittenQuery(original_query="q", strategy="hyde", search_queries=["q"]),
+        )
+        assert human_review(state) == {}    # hyde 전략은 interrupt 없이 통과
+
+    def test_already_approved_passes_through(self):
+        """이미 승인된 경우 decompose라도 통과"""
+        state = GraphState(
+            original_query="q",
+            rewritten_query=RewrittenQuery(original_query="q", strategy="decompose", search_queries=["q"]),
+            human_approved=True,
+        )
+        assert human_review(state) == {}    # 이미 승인된 경우 decompose라도 통과
+
+    def test_max_hil_count_reached_passes_through(self):
+        """MAX_HIL_COUNT 도달 시 무한 루프 방지를 위해 통과"""
+        state = GraphState(
+            original_query="q",
+            rewritten_query=RewrittenQuery(original_query="q", strategy="stepback", search_queries=["q"]),
+            hil_count=MAX_HIL_COUNT,
+        )
+        assert human_review(state) == {}    # MAX_HIL_COUNT 도달 시 무한 루프 방지를 위해 통과
+
+
+# ── E2E: 조건부 interrupt / resume ──────────────────────────────────────────────
+
+@pytest.mark.unit
+class TestHILInterruptResume:
+    THREAD = {"configurable": {"thread_id": "hil-test-1"}}
+
+    def _invoke_decompose(self, app, config):
+        """decompose 전략으로 분류되도록 강제하여 워크플로우를 invoke"""
+        with patch(
+            "src.agent.nodes.rewrite.classify_and_select",
+            return_value=(True, "decompose", 0.8),
+        ), patch("src.agent.nodes.rewrite.client") as mock_client:
+            mock_client.chat.completions.create.return_value = _mock_resp(
+                {"sub_queries": ["유형자산 감가상각은?", "무형자산 상각은?"]}
+            )
+            return app.invoke(GraphState(original_query=_decompose_state_query()), config=config)   # decompose 전략으로 강제 분기
+
+    def test_decompose_strategy_interrupts(self, hil_app):
+        """decompose 전략은 human_review에서 interrupt되어 search에 도달하지 않는다"""
+        result = self._invoke_decompose(hil_app, self.THREAD)
+
+        # interrupt 발생 확인
+        assert "__interrupt__" in result    # human_review 노드에서 interrupt 발생
+        payload = result["__interrupt__"][0].value
+        assert payload["type"] == "human_review"    # human_review 타입 확인
+        assert payload["strategy"] == "decompose"   # decompose 전략 확인
+        # 구조화된 선택지가 페이로드에 포함되어 클라이언트가 렌더링할 수 있어야 함
+        actions = {opt["action"] for opt in payload["options"]}
+        assert actions == {"approve", "rewrite"}    # approve와 rewrite 액션 확인
+
+        # search/generate 미도달 (조기 중단)
+        assert result.get("final_response") is None # 최종 응답이 생성되지 않음
+
+    def test_resume_approve_proceeds_to_search(self, hil_app, mock_searcher):
+        """approve로 재개하면 search→generate까지 진행되어 최종 응답이 생성된다"""
+        self._invoke_decompose(hil_app, self.THREAD)
+
+        resumed = hil_app.invoke(Command(resume={"action": "approve"}), config=self.THREAD)
+
+        assert "__interrupt__" not in resumed   # interrupt 발생하지 않음
+        mock_searcher.assert_called()                 # search 노드 진입
+        assert resumed["human_approved"] is True    # human_approved true
+        assert resumed["final_response"] is not None  # 최종 응답 생성 확인
+
+    def test_resume_rewrite_feedback_loops_back_and_reinterrupts(self, hil_app):
+        """재작성 요청으로 재개하면 rewrite로 루프백 후 다시 interrupt되고 hil_count가 증가한다"""
+        self._invoke_decompose(hil_app, self.THREAD)
+
+        # 루프백 시 rewrite가 다시 호출되므로 classify/client를 동일하게 패치
+        with patch(
+            "src.agent.nodes.rewrite.classify_and_select",
+            return_value=(True, "decompose", 0.8),
+        ), patch("src.agent.nodes.rewrite.client") as mock_client:
+            mock_client.chat.completions.create.return_value = _mock_resp(
+                {"sub_queries": ["유형자산 감가상각은?", "무형자산 상각은?"]}
+            )
+            resumed = hil_app.invoke(
+                Command(resume={"action": "rewrite", "feedback": "감가상각 내용연수를 강조해줘"}),
+                config=self.THREAD,
+            )
+
+        assert "__interrupt__" in resumed   # 재작성 후 다시 검토를 위해 interrupt가 발생해야 함
+        assert resumed["hil_count"] == 1    # HIL 재작성 횟수가 1 증가
+        assert resumed.get("human_feedback") is None    # 사용한 피드백은 rewrite에서 초기화됨
+        assert resumed["rewrite_count"] == 1 # HIL 루프백은 CRAG 카운터(rewrite_count)를 소비하지 않는다 (최초 진입 시의 1 유지)
+
+    def test_resume_rewrite_then_approve_completes(self, hil_app, mock_searcher):
+        """재작성 1회 후 승인하면 최종적으로 search까지 진행된다"""
+        self._invoke_decompose(hil_app, self.THREAD)
+
+        with patch(
+            "src.agent.nodes.rewrite.classify_and_select",
+            return_value=(True, "decompose", 0.8),
+        ), patch("src.agent.nodes.rewrite.client") as mock_client:
+            mock_client.chat.completions.create.return_value = _mock_resp(
+                {"sub_queries": ["유형자산 감가상각은?", "무형자산 상각은?"]}
+            )
+            hil_app.invoke(
+                Command(resume={"action": "rewrite", "feedback": "내용연수 강조"}),
+                config=self.THREAD,
+            )
+
+        resumed = hil_app.invoke(Command(resume={"action": "approve"}), config=self.THREAD)
+        assert "__interrupt__" not in resumed   # interrupt 발생하지 않음
+        # search 노드 진입
+        mock_searcher.assert_called()
+        assert resumed["final_response"] is not None  # 최종 응답 생성 확인
+
+
+# ── run_workflow / resume_workflow 진입점 ──────────────────────────────────────
+
+@pytest.mark.unit
+class TestRunResumeWorkflow:
+    def test_run_workflow_issues_thread_id(self):
+        """thread_id 미지정 시 UUID를 발급해 반환 dict에 포함한다"""
+        mock_app = MagicMock()
+        mock_app.invoke.return_value = {"original_query": "q", "final_response": "answer"}
+        with patch("src.agent.workflow.build_workflow", return_value=mock_app):
+            result = run_workflow("영업권 손상차손 인식 기준은?")
+        assert "thread_id" in result    # thread_id 포함 확인
+        assert isinstance(result["thread_id"], str) and result["thread_id"] # thread_id 유효성 확인
+        assert mock_app.step_timeout == 30 # step_timeout 확인
+
+    def test_run_workflow_reuses_given_thread_id(self):
+        """thread_id를 명시하면 그대로 사용한다"""
+        mock_app = MagicMock()
+        mock_app.invoke.return_value = {"original_query": "q"}
+        with patch("src.agent.workflow.build_workflow", return_value=mock_app):
+            result = run_workflow("q", thread_id="fixed-id")
+        assert result["thread_id"] == "fixed-id"    # thread_id 유지 확인
+
+    def test_resume_workflow_invokes_with_command_and_thread(self):
+        """resume_workflow가 Command(resume=...)와 thread_id config로 invoke한다"""
+        mock_app = MagicMock()
+        mock_app.invoke.return_value = {"final_response": "done"}
+        with patch("src.agent.workflow.build_workflow", return_value=mock_app):
+            result = resume_workflow("fixed-id", {"action": "approve"})
+
+        assert result["thread_id"] == "fixed-id"  # thread_id 유지 확인
+        call = mock_app.invoke.call_args
+        sent_command = call.args[0]
+        assert isinstance(sent_command, Command) # Command 객체 확인
+        assert sent_command.resume == {"action": "approve"} # Command.resume 인자 확인
+        assert call.kwargs["config"]["configurable"]["thread_id"] == "fixed-id" # thread_id config 확인
+
+    def test_run_workflow_interrupt_returns_payload_with_thread_id(self, mock_searcher):
+        """실제 그래프에서 decompose 질의가 interrupt되면 thread_id와 __interrupt__를 함께 반환한다"""
+        with patch(
+            "src.agent.nodes.rewrite.classify_and_select",
+            return_value=(True, "decompose", 0.8),
+        ), patch("src.agent.nodes.rewrite.client") as mock_client:
+            mock_client.chat.completions.create.return_value = _mock_resp(
+                {"sub_queries": ["a", "b"]}
+            )
+            result = run_workflow("유형자산과 무형자산 차이는?", thread_id="run-int-1")
+
+        assert result["thread_id"] == "run-int-1"   # thread_id 유지 확인
+        assert "__interrupt__" in result # interrupt 발생 확인
+
+        # 같은 thread_id로 resume하여 완료
+        resumed = resume_workflow("run-int-1", {"action": "approve"})
+        assert resumed["thread_id"] == "run-int-1" # thread_id 유지 확인
+        assert "__interrupt__" not in resumed   # interrupt 발생하지 않음
+        assert resumed["final_response"] is not None # 최종 응답 생성 확인

--- a/tests/unit/agent/test_rewrite.py
+++ b/tests/unit/agent/test_rewrite.py
@@ -57,7 +57,7 @@ class TestClassifyAndSelect:
             mock_client.chat.completions.create.return_value = _mock_resp(
                 {"is_accounting": True, "strategy": "hyde"}
             )
-            is_acc, strategy = classify_and_select("영업권 손상차손 인식 기준은?")
+            is_acc, strategy, confidence = classify_and_select("영업권 손상차손 인식 기준은?")
         assert is_acc is True
         assert strategy == "hyde"
 
@@ -66,7 +66,7 @@ class TestClassifyAndSelect:
             mock_client.chat.completions.create.return_value = _mock_resp(
                 {"is_accounting": True, "strategy": "decompose"}
             )
-            is_acc, strategy = classify_and_select("유형자산과 무형자산의 감가상각 방법 차이는?")
+            is_acc, strategy, confidence = classify_and_select("유형자산과 무형자산의 감가상각 방법 차이는?")
         assert is_acc is True
         assert strategy == "decompose"
 
@@ -75,7 +75,7 @@ class TestClassifyAndSelect:
             mock_client.chat.completions.create.return_value = _mock_resp(
                 {"is_accounting": True, "strategy": "stepback"}
             )
-            is_acc, strategy = classify_and_select("삼성전자 2023년 영업권 500억 손상 처리 기준은?")
+            is_acc, strategy, confidence = classify_and_select("삼성전자 2023년 영업권 500억 손상 처리 기준은?")
         assert is_acc is True
         assert strategy == "stepback"
 
@@ -84,21 +84,59 @@ class TestClassifyAndSelect:
             mock_client.chat.completions.create.return_value = _mock_resp(
                 {"is_accounting": False, "strategy": "bypass"}
             )
-            is_acc, strategy = classify_and_select("오늘 날씨 어때?")
+            is_acc, strategy, confidence = classify_and_select("오늘 날씨 어때?")
         assert is_acc is False
         assert strategy == "bypass"
 
     def test_llm_failure_fallback(self):
         with patch(self.PATCH) as mock_client:
             mock_client.chat.completions.create.side_effect = Exception("timeout")
-            is_acc, strategy = classify_and_select("영업권 손상차손 인식 기준은?")
+            is_acc, strategy, confidence = classify_and_select("영업권 손상차손 인식 기준은?")
         assert is_acc is True
         assert strategy == "hyde"
+        assert confidence == 0.0   # 폴백 시 신뢰도 0.0
+
+    def test_confidence_parsed_from_response(self):
+        # LLM이 반환한 confidence 값이 그대로 파싱되어야 함
+        with patch(self.PATCH) as mock_client:
+            mock_client.chat.completions.create.return_value = _mock_resp(
+                {"is_accounting": False, "strategy": "bypass", "confidence": 0.12}
+            )
+            is_acc, strategy, confidence = classify_and_select("오늘 날씨 어때?")
+        assert is_acc is False
+        assert confidence == 0.12
+
+    def test_confidence_missing_defaults_to_zero(self):
+        # confidence 키가 없으면 0.0으로 폴백
+        with patch(self.PATCH) as mock_client:
+            mock_client.chat.completions.create.return_value = _mock_resp(
+                {"is_accounting": True, "strategy": "hyde"}
+            )
+            _, _, confidence = classify_and_select("영업권 손상차손 인식 기준은?")
+        assert confidence == 0.0
+
+    def test_confidence_clamped_to_unit_range(self):
+        # 범위를 벗어난 값은 [0.0, 1.0]으로 클램프
+        with patch(self.PATCH) as mock_client:
+            mock_client.chat.completions.create.return_value = _mock_resp(
+                {"is_accounting": True, "strategy": "hyde", "confidence": 1.7}
+            )
+            _, _, confidence = classify_and_select("영업권 손상차손 인식 기준은?")
+        assert confidence == 1.0
+
+    def test_confidence_non_numeric_defaults_to_zero(self):
+        # 숫자로 변환 불가한 값은 0.0으로 폴백
+        with patch(self.PATCH) as mock_client:
+            mock_client.chat.completions.create.return_value = _mock_resp(
+                {"is_accounting": True, "strategy": "hyde", "confidence": "high"}
+            )
+            _, _, confidence = classify_and_select("영업권 손상차손 인식 기준은?")
+        assert confidence == 0.0
 
     def test_missing_keys_use_defaults(self):
         with patch(self.PATCH) as mock_client:
             mock_client.chat.completions.create.return_value = _mock_resp({})
-            is_acc, strategy = classify_and_select("영업권 손상차손 인식 기준은?")
+            is_acc, strategy, confidence = classify_and_select("영업권 손상차손 인식 기준은?")
         assert is_acc is True
         assert strategy == "hyde"
 
@@ -107,7 +145,7 @@ class TestClassifyAndSelect:
         wrapped = "```json\n{\"is_accounting\": false, \"strategy\": \"bypass\"}\n```"
         with patch(self.PATCH) as mock_client:
             mock_client.chat.completions.create.return_value = _mock_raw_resp(wrapped)
-            is_acc, strategy = classify_and_select("오늘 날씨 어때?")
+            is_acc, strategy, confidence = classify_and_select("오늘 날씨 어때?")
         assert is_acc is False
         assert strategy == "bypass"
 
@@ -117,7 +155,7 @@ class TestClassifyAndSelect:
             mock_client.chat.completions.create.return_value = _mock_resp(
                 {"is_accounting": "False", "strategy": "bypass"}
             )
-            is_acc, strategy = classify_and_select("오늘 날씨 어때?")
+            is_acc, strategy, confidence = classify_and_select("오늘 날씨 어때?")
         assert is_acc is False
 
     def test_string_true_treated_as_true(self):
@@ -125,7 +163,7 @@ class TestClassifyAndSelect:
             mock_client.chat.completions.create.return_value = _mock_resp(
                 {"is_accounting": "True", "strategy": "hyde"}
             )
-            is_acc, strategy = classify_and_select("영업권 손상차손 인식 기준은?")
+            is_acc, strategy, confidence = classify_and_select("영업권 손상차손 인식 기준은?")
         assert is_acc is True
 
 
@@ -260,12 +298,14 @@ class TestRewriteQuery:
     def test_non_accounting_sets_bypass(self):
         with patch(self.PATCH) as mock_client:
             mock_client.chat.completions.create.return_value = _mock_resp(
-                {"is_accounting": False, "strategy": "bypass"}
+                {"is_accounting": False, "strategy": "bypass", "confidence": 0.95}
             )
             state = rewrite_query(self._make_state("오늘 날씨 어때?"))
         assert state.is_accounting_query is False
         assert state.rewritten_query.strategy == "bypass"
         assert state.rewritten_query.search_queries == ["오늘 날씨 어때?"]
+        # 비회계 조기 종료 시 early_exit가 사용할 분류 신뢰도가 state에 기록되어야 함
+        assert state.classification_confidence == 0.95
 
     def test_accounting_hyde_strategy(self):
         with patch(self.PATCH) as mock_client:
@@ -304,7 +344,7 @@ class TestRewriteQuery:
         # 예외가 rewrite_query까지 전파되므로 error_logs에 기록됨
         # cf. test_all_llm_failure: 각 함수가 예외를 내부에서 삼키므로 outer except 미발동
         with patch("src.agent.nodes.rewrite.classify_and_select") as mock_classify:
-            mock_classify.return_value = (True, "unknown_strategy")
+            mock_classify.return_value = (True, "unknown_strategy", 0.8)
             state = rewrite_query(self._make_state("영업권 손상차손 인식 기준은?"))
         assert state.rewritten_query.strategy == "bypass"
         assert state.rewritten_query.search_queries == ["영업권 손상차손 인식 기준은?"]

--- a/tests/unit/agent/test_rewrite.py
+++ b/tests/unit/agent/test_rewrite.py
@@ -12,6 +12,12 @@ from src.agent.nodes.rewrite import (
 from src.models.state import GraphState
 
 
+def _last_user_content(mock_client) -> str:
+    """가장 최근 client.chat.completions.create 호출의 사용자 메시지 본문을 반환"""
+    call = mock_client.chat.completions.create.call_args
+    return call.kwargs["messages"][0]["content"]
+
+
 def _mock_resp(content: dict) -> MagicMock:
     # OpenAI 응답 객체를 흉내 낸 가짜 객체 생성
     # content 딕셔너리를 JSON 문자열로 변환해 resp.choices[0].message.content에 실제로 저장
@@ -382,3 +388,60 @@ class TestRewriteQuery:
             ]
             state = rewrite_query(GraphState(original_query=query))
         assert state.rewritten_query.original_query == query
+
+
+# ── HIL 피드백 주입 (apply_* / rewrite_query) ───────────────────────────────────
+
+@pytest.mark.unit
+class TestFeedbackInjection:
+    PATCH = "src.agent.nodes.rewrite.client"
+    FEEDBACK = "리스 회계처리를 강조해줘"
+
+    def test_apply_hyde_injects_feedback_into_prompt(self):
+        with patch(self.PATCH) as mock_client:
+            mock_client.chat.completions.create.return_value = _mock_resp(
+                {"hypothetical_answer": "..."}
+            )
+            apply_hyde("리스부채 최초 인식 방법은?", "ALL", feedback=self.FEEDBACK)
+        content = _last_user_content(mock_client)
+        assert self.FEEDBACK in content        # 피드백이 프롬프트에 포함
+        assert "[사용자 추가 요청]" in content   # 제약 문구 헤더 포함
+
+    def test_apply_hyde_without_feedback_omits_clause(self):
+        with patch(self.PATCH) as mock_client:
+            mock_client.chat.completions.create.return_value = _mock_resp(
+                {"hypothetical_answer": "..."}
+            )
+            apply_hyde("리스부채 최초 인식 방법은?", "ALL")
+        content = _last_user_content(mock_client)
+        assert "[사용자 추가 요청]" not in content   # 피드백 없으면 절 미포함
+
+    def test_apply_decompose_injects_feedback(self):
+        with patch(self.PATCH) as mock_client:
+            mock_client.chat.completions.create.return_value = _mock_resp(
+                {"sub_queries": ["a", "b"]}
+            )
+            apply_decompose("유형자산과 무형자산 차이는?", "ALL", feedback=self.FEEDBACK)
+        assert self.FEEDBACK in _last_user_content(mock_client)
+
+    def test_apply_stepback_injects_feedback(self):
+        with patch(self.PATCH) as mock_client:
+            mock_client.chat.completions.create.return_value = _mock_resp(
+                {"abstract_query": "..."}
+            )
+            apply_stepback("삼성전자 2023년 영업권 손상은?", "ALL", feedback=self.FEEDBACK)
+        assert self.FEEDBACK in _last_user_content(mock_client) 
+
+    def test_rewrite_query_passes_feedback_and_clears_it(self):
+        # state.human_feedback이 전략 프롬프트에 주입되고, 사용 후 None으로 초기화되어야 함
+        state = GraphState(original_query="리스부채 최초 인식 방법은?", human_feedback=self.FEEDBACK)
+        with patch(self.PATCH) as mock_client:
+            mock_client.chat.completions.create.side_effect = [
+                _mock_resp({"is_accounting": True, "strategy": "hyde", "confidence": 0.9}),
+                _mock_resp({"hypothetical_answer": "리스부채는 현재가치로 측정합니다."}),
+            ]
+            result = rewrite_query(state)
+
+        strategy_call = mock_client.chat.completions.create.call_args_list[1] 
+        assert self.FEEDBACK in strategy_call.kwargs["messages"][0]["content"]  # 두 번째 호출(전략 프롬프트)에 피드백이 포함되었는지 검증
+        assert result.human_feedback is None    # 사용 후 초기화 (다음 루프 대비)

--- a/tests/unit/agent/test_workflow.py
+++ b/tests/unit/agent/test_workflow.py
@@ -1,10 +1,16 @@
 import pytest
 from langgraph.graph.state import CompiledStateGraph
 from unittest.mock import MagicMock, patch
-from src.agent.workflow import route_after_evaluate, search, run_workflow
+from src.agent.workflow import (
+    route_after_evaluate,
+    route_after_rewrite,
+    early_exit,
+    search,
+    run_workflow,
+)
 from src.models.state import GraphState
 from src.utils.config import MAX_REWRITE_COUNT
-from src.models.schemas import EvaluationResult
+from src.models.schemas import EvaluationResult, FinalResponse
 from src.utils.exception import SearchTimeoutError, DatabaseQueryError, NoContextFoundError
 
 @pytest.fixture(autouse=True)
@@ -36,10 +42,10 @@ class TestWorkflowConstruction:
         assert isinstance(workflow_app, CompiledStateGraph)
 
     def test_workflow_has_required_nodes(self, workflow_app):
-        """5개 노드(rewrite, search, rerank, evaluate, generate) 등록 여부 검증"""
+        """6개 노드(rewrite, early_exit, search, rerank, evaluate, generate) 등록 여부 검증"""
         # 추상화된 CompiledStateGraph에서 .get_graph()를 통해 독립적인 Graph 객체를 얻고, 노드 목록을 가져옴
         nodes = workflow_app.get_graph().nodes
-        required_nodes = ["rewrite", "search", "rerank", "evaluate", "generate"]
+        required_nodes = ["rewrite", "early_exit", "search", "rerank", "evaluate", "generate"]
         for node in required_nodes:
             assert node in nodes
 
@@ -52,11 +58,15 @@ class TestWorkflowConstruction:
         # START/END 엣지 확인
         assert ("__start__", "rewrite") in edges    # start에서 rewrite로 시작
         assert ("generate", "__end__") in edges     # generate에서 종료
+        assert ("early_exit", "__end__") in edges   # 비회계 조기 종료
 
         # 직렬 엣지 확인
-        assert ("rewrite", "search") in edges       # rewrite에서 search로 이동
         assert ("search", "rerank") in edges        # search에서 rerank로 이동
         assert ("rerank", "evaluate") in edges      # rerank에서 evaluate로 이동
+
+        # rewrite 직후 조건부 라우팅 엣지 확인 (rewrite → search, rewrite → early_exit)
+        assert ("rewrite", "search") in conditional_edges       # 회계 질의 → search
+        assert ("rewrite", "early_exit") in conditional_edges   # 비회계 질의 → early_exit
 
         # 조건부 라우팅 엣지 확인 (evaluate → rewrite, evaluate → generate)
         assert ("evaluate", "rewrite") in conditional_edges # evaluate에서 evaluate로 재귀
@@ -221,6 +231,59 @@ class TestCRAGLoopPath:
         assert final_state["rewrite_count"] == MAX_REWRITE_COUNT    # 최대 재시도 횟수에 도달했는지 확인
         assert final_state["final_response"] is not None            # 루프 종료 후 최선의 답변이 반환됐는지 확인
         assert final_state["evaluation"].needs_external is True     # 루프 종료 사유가 max count임을 간접 검증
+
+
+@pytest.mark.unit
+class TestEarlyExitRouting:
+    """비회계 질문 조기 종료 라우팅(route_after_rewrite, early_exit) 검증"""
+
+    def test_route_after_rewrite_non_accounting_to_early_exit(self):
+        """is_accounting_query=False → early_exit 반환"""
+        state = GraphState(original_query="대한민국 수도는 어디야?", is_accounting_query=False)
+        assert route_after_rewrite(state) == "early_exit"   # route_after_rewrite가 early_exit로 라우팅되는지 확인
+
+    def test_route_after_rewrite_accounting_to_search(self):
+        """is_accounting_query=True → search 반환"""
+        state = GraphState(original_query="영업권 손상차손 인식 기준은?", is_accounting_query=True)
+        assert route_after_rewrite(state) == "search"   # route_after_rewrite가 search로 라우팅되는지 확인
+
+    def test_early_exit_builds_final_response_with_confidence(self):
+        """early_exit 노드가 안내 응답과 분류 신뢰도를 담은 FinalResponse를 생성"""
+        state = GraphState(
+            original_query="대한민국 수도는 어디야?",
+            is_accounting_query=False,
+            classification_confidence=0.88,
+        )
+        result = early_exit(state)
+        fr = result["final_response"]
+        assert isinstance(fr, FinalResponse)   # early_exit가 FinalResponse를 생성하는지 확인
+        assert fr.answer == "죄송합니다. 회계 관련 질문을 해 주세요."   # early_exit가 안내 응답을 생성하는지 확인
+        assert fr.is_answerable is False   # early_exit가 is_answerable=False를 설정하는지 확인
+        assert fr.citations == []   # early_exit가 citations=[]로 설정하는지 확인
+        # 고정값이 아니라 rewrite가 기록한 실제 분류 신뢰도가 전달되어야 함
+        assert fr.confidence_score == 0.88   # early_exit가 confidence_score를 설정하는지 확인
+
+    def test_non_accounting_query_skips_pipeline_e2e(self, workflow_app, initial_state, mock_searcher):
+        """비회계 질의는 search/rerank/evaluate/generate를 거치지 않고 즉시 종료된다 (E2E)"""
+        with patch(
+            "src.agent.nodes.rewrite.classify_and_select",
+            return_value=(False, "bypass", 0.9),
+        ):
+            final_state = workflow_app.invoke(initial_state)
+
+        # 하위 검색 파이프라인이 호출되지 않았는지 확인
+        # (조기 종료 경로에서는 해당 채널이 한 번도 갱신되지 않으므로 .get으로 안전하게 조회)
+        mock_searcher.assert_not_called()
+        assert final_state.get("retrieved_chunks", []) == []    # retrieved_chunks가 []인지 확인
+        assert final_state.get("reranked_chunks", []) == []    # reranked_chunks가 []인지 확인
+        assert final_state.get("evaluation") is None    # evaluation이 None인지 확인
+
+        # 조기 종료 응답 검증
+        fr = final_state["final_response"]
+        assert fr is not None    # early_exit가 FinalResponse를 생성하는지 확인
+        assert fr.is_answerable is False    # early_exit가 is_answerable=False를 설정하는지 확인
+        assert fr.confidence_score == 0.9    # early_exit가 confidence_score를 설정하는지 확인
+        assert "회계 관련 질문" in fr.answer    # early_exit가 안내 응답을 생성하는지 확인
 
 
 @pytest.mark.unit

--- a/tests/unit/agent/test_workflow.py
+++ b/tests/unit/agent/test_workflow.py
@@ -64,9 +64,13 @@ class TestWorkflowConstruction:
         assert ("search", "rerank") in edges        # search에서 rerank로 이동
         assert ("rerank", "evaluate") in edges      # rerank에서 evaluate로 이동
 
-        # rewrite 직후 조건부 라우팅 엣지 확인 (rewrite → search, rewrite → early_exit)
-        assert ("rewrite", "search") in conditional_edges       # 회계 질의 → search
-        assert ("rewrite", "early_exit") in conditional_edges   # 비회계 질의 → early_exit
+        # rewrite 직후 조건부 라우팅 엣지 확인 (rewrite → human_review, rewrite → early_exit)
+        assert ("rewrite", "human_review") in conditional_edges  # 회계 질의 → human_review
+        assert ("rewrite", "early_exit") in conditional_edges    # 비회계 질의 → early_exit
+
+        # human_review 직후 조건부 라우팅 엣지 확인 (human_review → search, human_review → rewrite)
+        assert ("human_review", "search") in conditional_edges   # 승인/통과 → search
+        assert ("human_review", "rewrite") in conditional_edges  # 재작성 요청 → rewrite 루프백
 
         # 조건부 라우팅 엣지 확인 (evaluate → rewrite, evaluate → generate)
         assert ("evaluate", "rewrite") in conditional_edges # evaluate에서 evaluate로 재귀
@@ -242,10 +246,10 @@ class TestEarlyExitRouting:
         state = GraphState(original_query="대한민국 수도는 어디야?", is_accounting_query=False)
         assert route_after_rewrite(state) == "early_exit"   # route_after_rewrite가 early_exit로 라우팅되는지 확인
 
-    def test_route_after_rewrite_accounting_to_search(self):
-        """is_accounting_query=True → search 반환"""
+    def test_route_after_rewrite_accounting_to_human_review(self):
+        """is_accounting_query=True → human_review 반환 (HIL 적용 여부는 human_review가 결정)"""
         state = GraphState(original_query="영업권 손상차손 인식 기준은?", is_accounting_query=True)
-        assert route_after_rewrite(state) == "search"   # route_after_rewrite가 search로 라우팅되는지 확인
+        assert route_after_rewrite(state) == "human_review"   # 회계 질의는 human_review로 진행
 
     def test_early_exit_builds_final_response_with_confidence(self):
         """early_exit 노드가 안내 응답과 분류 신뢰도를 담은 FinalResponse를 생성"""

--- a/tests/unit/agent/test_workflow_to_completion.py
+++ b/tests/unit/agent/test_workflow_to_completion.py
@@ -1,0 +1,68 @@
+"""
+run_workflow_to_completion 헬퍼(#90) 단위 테스트
+
+라이브 LLM/Docker 없이 run_workflow/resume_workflow를 모킹하여 auto-approve 루프와
+상한 가드 동작을 검증한다.
+"""
+import pytest
+from unittest.mock import patch
+
+from tests.integration.helpers import (
+    run_workflow_to_completion,
+    _MAX_AUTO_APPROVE,
+)
+
+
+@pytest.mark.unit
+class TestRunWorkflowToCompletion:
+    def test_passthrough_when_no_interrupt(self):
+        """interrupt가 없으면 run_workflow 결과를 그대로 반환하고 resume을 호출하지 않는다."""
+        completed = {"thread_id": "t1", "final_response": "answer"}
+        with patch(
+            "tests.integration.helpers.run_workflow", return_value=completed
+        ) as mock_run, patch(
+            "tests.integration.helpers.resume_workflow"
+        ) as mock_resume:
+            result = run_workflow_to_completion("회계 질의", standard_filter="KIFRS")
+
+        assert result is completed
+        mock_run.assert_called_once_with("회계 질의", standard_filter="KIFRS")
+        mock_resume.assert_not_called()
+
+    def test_auto_approves_until_completion(self):
+        """interrupt 상태면 approve로 재개하여 __interrupt__가 소거될 때까지 진행한다."""
+        interrupted = {"thread_id": "t1", "__interrupt__": [{"value": {}}]}
+        completed = {"thread_id": "t1", "final_response": "answer"}
+        with patch(
+            "tests.integration.helpers.run_workflow", return_value=interrupted
+        ), patch(
+            "tests.integration.helpers.resume_workflow", return_value=completed
+        ) as mock_resume:
+            result = run_workflow_to_completion("복잡한 회계 질의")
+
+        assert result is completed
+        assert "__interrupt__" not in result
+        mock_resume.assert_called_once_with("t1", {"action": "approve"})
+
+    def test_raises_when_loop_never_terminates(self):
+        """resume이 계속 interrupt를 반환하면 _MAX_AUTO_APPROVE 초과 시 RuntimeError."""
+        interrupted = {"thread_id": "t1", "__interrupt__": [{"value": {}}]}
+        with patch(
+            "tests.integration.helpers.run_workflow", return_value=interrupted
+        ), patch(
+            "tests.integration.helpers.resume_workflow", return_value=interrupted
+        ) as mock_resume:
+            with pytest.raises(RuntimeError, match="auto-approve 루프 상한"):
+                run_workflow_to_completion("종료되지 않는 질의")
+
+        # 초기 run 1회 + resume을 상한 횟수만큼 호출한 뒤 다음 시도에서 가드 발동
+        assert mock_resume.call_count == _MAX_AUTO_APPROVE
+
+    def test_asserts_thread_id_present_on_interrupt(self):
+        """interrupt 상태에 thread_id가 없으면 #79 계약 위반으로 AssertionError."""
+        bad = {"__interrupt__": [{"value": {}}]}
+        with patch(
+            "tests.integration.helpers.run_workflow", return_value=bad
+        ), patch("tests.integration.helpers.resume_workflow"):
+            with pytest.raises(AssertionError, match="thread_id"):
+                run_workflow_to_completion("질의")

--- a/tests/unit/test_node_contracts.py
+++ b/tests/unit/test_node_contracts.py
@@ -56,10 +56,10 @@ class TestRewriteNodeContract:
     @patch("src.agent.nodes.rewrite.classify_and_select")
     def test_rewrite_fallback_contract(self, mock_classify):
         """Fallback 동작 검증:
-        1. classify_and_select 패치를 통해 (True, "invalid_strategy") 반환.
+        1. classify_and_select 패치를 통해 (True, "invalid_strategy", 0.7) 반환.
         2. 발생하는 KeyError를 통해 strategy="bypass"로 폴백 및 error_logs 기록 검증.
         """
-        mock_classify.return_value = (True, "invalid_strategy")
+        mock_classify.return_value = (True, "invalid_strategy", 0.7)
 
         state = GraphState(
             original_query="영업권 손상차손 인식 기준은?",


### PR DESCRIPTION
## 개요

질의 재작성(rewrite) 노드 직후의 **라우팅을 고도화**합니다. 두 가지 목적을 다룹니다.

1. **비회계 질문 조기 종료 (#78)** — 비회계 질의가 검색·재정렬·평가·생성 전체 파이프라인을 타며 불필요한 LLM 호출/지연을 유발하던 문제를 해결합니다. `rewrite` 직후 분기하여 안내 응답만 반환하고 즉시 종료합니다.
2. **조건부 Human-in-the-Loop (#79)** — `decompose`·`stepback`처럼 복잡·추상화가 필요한 재작성 결과에 대해, 검색 전에 사용자 확인·피드백을 받는 HIL 단계를 도입합니다.

---

## 변경 사항

### 신규 구현

- **`tests/unit/agent/test_hil_workflow.py`** — HIL 단위/E2E 테스트 (interrupt·resume·루프백·진입점, 18 케이스)

### 수정

- **`src/agent/workflow.py`** — `early_exit`·`human_review` 노드 추가, `route_after_rewrite`·`route_after_human_review` 분기, `MemorySaver` 체크포인터, `run_workflow(thread_id)`·`resume_workflow` 진입점
- **`src/agent/nodes/rewrite.py`** — `classify_and_select` 반환을 `tuple[bool, str, float]`로 확장(분류 신뢰도), `human_feedback`를 전략 프롬프트에 주입 후 초기화
- **`src/agent/prompts.py`** — `CLASSIFY_STRATEGY_PROMPT`에 `confidence` 필드 요청 추가
- **`src/models/state.py`** — `classification_confidence`, `human_feedback`·`human_approved`·`hil_count` 필드 추가
- **`src/utils/config.py`** — `MAX_HIL_COUNT = 5` 추가 (CRAG 루프와 분리)
- **`tests/unit/agent/test_rewrite.py`** — 신뢰도 파싱·피드백 주입 테스트 추가
- **`tests/unit/agent/test_workflow.py`** — `rewrite → human_review` 토폴로지 및 조기 종료 라우팅 테스트 갱신
- **`tests/unit/test_node_contracts.py`** — `classify_and_select` 3-튜플 반환에 맞춰 계약 테스트 갱신

---

## 아키텍처

### 처리 흐름

```text
사용자 질의
    │
    ▼
rewrite (classify_and_select)
    │
    ▼
route_after_rewrite
    ├─ is_accounting=false → early_exit → END   (안내 응답, confidence_score=LLM 분류 신뢰도)
    └─ is_accounting=true  → human_review
                                 │
                                 ▼
                          route_after_human_review
                            ├─ hyde / 이미 승인 / 최대 횟수 도달 → search → rerank → evaluate → generate → END
                            └─ decompose·stepback → interrupt() (사용자 확인)
                                   ├─ action=approve         → search ...
                                   └─ action=rewrite(feedback) → rewrite 루프백 (피드백 프롬프트 주입)
```

### 주요 설계 결정

**노드 역할 분리 — `early_exit` 별도 노드 (#78)**
`rewrite`가 `FinalResponse`를 직접 만들지 않고 분류·재작성에만 전념합니다. 비회계 판단 시 `route_after_rewrite`가 `early_exit`로 분기해 응답을 생성하고 `END`로 종료합니다. 추후 비회계 응답 포맷/로깅 변경 시 `early_exit`만 수정하면 됩니다.

**`confidence_score` — LLM 실제 분류 신뢰도 (#78)**
고정값(`0.0`/`1.0`) 대신 LLM이 보고한 분류 신뢰도(0.0~1.0)를 `early_exit`가 `FinalResponse.confidence_score`로 전달합니다. 운영 단계에서 분류 경계가 모호한(낮은 신뢰도) 케이스를 추출·분석해 프롬프트 개선에 활용할 수 있습니다.

**조건부 HIL — 전략 기반 트리거 (#79)**
모든 질의가 아니라 `human_review` 노드가 선택된 전략에 따라 중단 여부를 결정합니다. `decompose`·`stepback`만 `interrupt()`로 중단하고 단순 `hyde`는 바로 `search`로 통과합니다. (운영 데이터 축적 후 `classification_confidence` 기반 조건 추가 검토)

**HIL 구현 위치 — `human_review` 노드 내부 `interrupt()` (#79)**
`interrupt_after=["rewrite"]`(항상 중단) 대신, `human_review` 노드 내부에서 조건부로 `interrupt()`를 호출합니다. 구조화된 선택지(`options`)를 페이로드에 포함해 클라이언트가 UI로 렌더링합니다.

**상태 저장 — `MemorySaver` + `thread_id` (#79)**
MVP 단계에서 인메모리 `MemorySaver`를 사용합니다. `run_workflow`가 최초 호출 시 `thread_id`(UUID)를 발급·반환하고, 클라이언트는 `resume_workflow(thread_id, {"action": ...})`로 재개합니다. 실서비스 전환 시 `AsyncPostgresSaver`로 교체 예정(인터페이스 통일).

**카운터 분리 — `MAX_HIL_COUNT` ≠ `MAX_REWRITE_COUNT` (#79)**
CRAG 루프(`rewrite_count`)와 HIL 재작성 루프(`hil_count`)는 성격이 달라 카운터를 분리합니다. HIL 피드백으로 인한 `rewrite` 재진입은 `rewrite_count`를 증가시키지 않습니다.

---

## 체크리스트

- [x] 단위 테스트 전체 통과 (188 passed, 9 skipped)
- [x] 비회계 질의 조기 종료 E2E 검증 (하위 파이프라인 미호출)
- [x] HIL interrupt → approve/rewrite resume → 루프백 시나리오 검증
- [x] 피드백 프롬프트 주입 및 사용 후 초기화 검증
- [x] CRAG 카운터와 HIL 카운터 분리 검증
- [ ] 벤치마크 통합 테스트 호환성 (HIL interrupt로 `final_response=None` 가능) — #90 에서 후속 진행

---

Closes #78
Closes #79
Refs #90

🤖 Generated with [Claude Code](https://claude.com/claude-code)
