### PR TITLE
test: fix Phase 1 system test fixtures (GN-401 citation guard & search mocking) (#107)

### DIFF
--- a/tests/integration/inference/conftest.py
+++ b/tests/integration/inference/conftest.py
@@ -11,9 +11,13 @@ def mock_llm_agent():
     generate_response()는 실행 시점에 Agent를 생성하므로,
     LazyAppProxy로 지연 빌드하는 워크플로우에도 이 patch가 적용된다.
     generate_response 자체를 workflow 레벨에서 통째로 대체하는 테스트(happy_path 등)에는 문제가 없다
+
+    answer에 "[1]" 인용 마크업을 포함시키는 이유:
+        generate 노드의 GN-401 가드(generate.py)는 is_answerable=True인데 인용 근거가 하나도 없으면 LLMResponseFormatError를 발생시킨다.
+        chunk_map은 항상 인덱스 1부터 시작하므로 "[1]"이 있으면 최소 1건의 citation이 추출되어 GN-401 계약을 만족한다.
     """
     llm_response = LLMInternalResponse(
-        answer="테스트 답변입니다.",
+        answer="테스트 답변입니다. [1]",
         is_answerable=True,
         llm_self_score=0.9
     )

--- a/tests/integration/inference/test_scenario_hallucination_risk.py
+++ b/tests/integration/inference/test_scenario_hallucination_risk.py
@@ -117,6 +117,7 @@ class TestScenarioHallucinationRisk:
         """특정 노드에서 예외 발생 시 CRAG 루프에 진입하지 않고
         안전하게 generate로 직행하는 Fallback 경로를 검증"""
 
+        from contextlib import ExitStack    # 여러 컨텍스트를 한 번에 관리하기 위한 모듈
         from src.agent.workflow import handle_node_errors
 
         def raise_error(state):
@@ -129,7 +130,14 @@ class TestScenarioHallucinationRisk:
             "search": "src.agent.workflow.search",
         }[error_node]
 
-        with patch(patch_target, side_effect=decorated):
+        with ExitStack() as stack:
+            # search가 에러 대상 노드가 아니면 실제 DB 접근(relation "chunks")을 막기 위해 가짜 청크로 모킹
+            if error_node != "search":
+                stack.enter_context(
+                    patch("src.agent.workflow.search",
+                          return_value={"retrieved_chunks": make_retrieved_chunks()})
+                )
+            stack.enter_context(patch(patch_target, side_effect=decorated))
             state = GraphState(original_query="에러 복구 테스트", standard_filter="ALL")
             final_state = mocked_app.invoke(state)
 

--- a/tests/integration/inference/test_scenario_no_context.py
+++ b/tests/integration/inference/test_scenario_no_context.py
@@ -109,6 +109,7 @@ class TestScenarioNoContext:
         """특정 노드에서 예외 발생 시 파이프라인이 중단되지 않고,
         error_logs에 정확한 에러 정보를 기록한 뒤 안전하게 답변 불가로 종료되는지 검증"""
 
+        from contextlib import ExitStack    # 여러 컨텍스트를 한 번에 관리하기 위한 모듈
         from src.agent.workflow import handle_node_errors
 
         # 예외를 발생시키는 노드 함수 생성
@@ -123,7 +124,15 @@ class TestScenarioNoContext:
             "rerank": "src.agent.workflow.rerank",
         }[expected_node]
 
-        with patch(patch_target, side_effect=decorated):
+        with ExitStack() as stack:
+            # search가 에러 대상 노드가 아니면 실제 DB 접근(relation "chunks")을 막기 위해
+            # 가짜 청크로 모킹한다 (Phase 1 시스템 테스트는 외부 의존성이 없어야 한다).
+            if expected_node != "search":
+                stack.enter_context(
+                    patch("src.agent.workflow.search",
+                          return_value={"retrieved_chunks": make_retrieved_chunks()})
+                )
+            stack.enter_context(patch(patch_target, side_effect=decorated))
             state = GraphState(original_query="영업권 손상차손 인식 기준은?", standard_filter="ALL")
             final_state = mocked_app.invoke(state)
 


### PR DESCRIPTION
## 개요

`uv run python tests/run_tests.py --phase1-only` 실행 시 **Phase 1 (System Integration)** 에서 7개 테스트가 실패하던 문제를 해결합니다. 원인은 서로 다른 **두 가지**이며, 둘 다 프로덕션 로직 결함이 아니라 **테스트 픽스처/모킹 설계 결함**입니다. Phase 1이 실패하면 `run_tests.py`가 `sys.exit(1)`로 중단되어 Phase 2(Benchmark)까지 차단되므로 우선 해소합니다.

```
(before) 7 failed, 22 passed, 46 deselected
(after)  29 passed, 46 deselected
```

---

## 변경 사항

### 원인 A — GN-401 인용 가드와 mock 답변 불일치 (5건)

- **`tests/integration/inference/conftest.py`** — `mock_llm_agent` 픽스처의 mock 답변에 인용 마크업 추가 (`"테스트 답변입니다."` → `"테스트 답변입니다. [1]"`)

GN-401 가드 도입(#53) 이후, mock 답변에 `[n]` 인용이 없어 `is_answerable=True`임에도 `extracted_citations`가 비어 `LLMResponseFormatError`가 발생했고, `build_unanswerable_response()`(`is_answerable=False`)로 폴백되어 테스트가 기대한 `is_answerable=True`가 무너졌습니다. `chunk_map`은 항상 인덱스 1부터 시작하므로 `[1]`이 최소 1건의 citation을 보장하여 GN-401 계약을 만족합니다.

해소된 케이스:
- `test_scenario_hallucination_risk.py::test_crag_loop_rewrite_count_evolution[no_loop / single_retry / double_retry]`
- `test_scenario_no_context.py::test_pipeline_with_varying_search_results[single_pass]`
- `test_scenario_no_context.py::test_rerank_failure_fallback_preserves_retrieved_chunks`

### 원인 B — search 노드 미모킹으로 실제 DB 접근 (2건)

- **`tests/integration/inference/test_scenario_hallucination_risk.py`** — `test_node_error_fallback_routing`에 조건부 search 모킹 추가
- **`tests/integration/inference/test_scenario_no_context.py`** — `test_pipeline_node_exception_graceful_degradation`에 조건부 search 모킹 추가

`evaluate`/`rerank` 노드만 패치하고 `search`를 패치하지 않아 실제 `search_chunks()`가 `FROM chunks` 쿼리를 실제 Postgres에 날려 `UndefinedTable(relation "chunks" does not exist)`이 발생했습니다. `ExitStack`을 사용해 **search가 에러 대상 노드가 아닐 때만** 가짜 청크로 모킹하여, search 자체를 에러 버전으로 패치하는 형제 케이스(`search_error_fallback` / `search_timeout_error`)와 충돌하지 않도록 했습니다. Phase 1 설계 원칙(외부 의존성 없음)에 부합합니다.

해소된 케이스:
- `test_scenario_hallucination_risk.py::test_node_error_fallback_routing[evaluate_error_fallback]`
- `test_scenario_no_context.py::test_pipeline_node_exception_graceful_degradation[rerank_threshold_error]`

---

## 근본 원인 분석

| 원인 | 증상 | 트리거 | 성격 |
|------|------|--------|------|
| A | `assert False is True` (`is_answerable=False`) | GN-401 가드 도입(#53, `4e759e0`) 이후 mock 답변이 계약 위반 | 픽스처 결함 |
| B | `psycopg.errors.UndefinedTable: relation "chunks" does not exist` | `search` 노드 미모킹으로 실제 DB 접근 | 모킹 누락 |

두 원인 모두 프로덕션 코드(`generate.py`, `workflow.py`, `searcher.py`)의 동작은 정상이며, **테스트 자산 결함**입니다.

---

## 체크리스트

- [x] 원인 A 5건 통과 검증
- [x] 원인 B 2건 통과 + 형제 케이스(`search_error_fallback` / `search_timeout_error`) 회귀 없음 확인
- [x] Phase 1 전체 통과 (`29 passed, 46 deselected`)
- [x] 프로덕션 코드 무변경 (테스트 자산만 수정)
