### PR TITLE
fix: resolver, Section/Standard 해소 시 to_paragraph 오설정 방지 (#69)

### DIFF
--- a/src/db/ontology/resolver.py
+++ b/src/db/ontology/resolver.py
@@ -104,6 +104,9 @@ def resolve_edges(graph: OntologyGraph) -> OntologyGraph:
       4. 실패 시 장 번호(제N장) 패턴만 추출해서 재시도 (최후 수단)
     """
     lookup = build_lookup(graph)
+    # to_paragraph는 Subsection으로 해소된 경우에만 설정한다.
+    # 해소된 노드의 node_type을 확인하기 위한 매핑.
+    node_type_map = {node.id: node.node_type for node in graph.nodes}
     # 그래프의 모든 paragraphs를 등장 순서대로 수집 (범위 확장에 사용)
     paragraphs_in_order: list[str] = []
     for node in graph.nodes:
@@ -172,10 +175,11 @@ def resolve_edges(graph: OntologyGraph) -> OntologyGraph:
 
         if target_id:
             # 성공: to_id 채우고 unresolved_target 비우기.
-            # norm에서 문단 번호를 추출해 to_paragraph에 저장한다.
-            # 절·장으로만 해소된 경우 _PARA_RE가 매칭되지 않으므로 to_paragraph는 빈 문자열이 된다.
+            # to_paragraph는 Subsection으로 해소됐을 때만 norm에서 문단 번호를 추출해 저장한다.
+            # 절·장으로 해소된 경우, norm에 문단 패턴("6.4")이 섞여 있어도
+            # (예: "제2절 문단 6.4") 그 Section/Standard에 해당 문단이 없을 수 있으므로 빈 문자열로 남긴다.
             m = _PARA_RE.search(norm)
-            to_para = m.group(1) if m else ""
+            to_para = m.group(1) if (m and node_type_map.get(target_id) == "Subsection") else ""
             resolved.append(edge.model_copy(update={
                 "to_id": target_id,
                 "unresolved_target": "",

--- a/tests/unit/ontology/test_resolver.py
+++ b/tests/unit/ontology/test_resolver.py
@@ -39,6 +39,34 @@ def test_resolve_success():
     assert resolved.edges[0].unresolved_target == ""
 
 
+def test_resolve_section_does_not_set_to_paragraph():
+    """절로 해소된 엣지는 norm에 문단 패턴이 섞여 있어도 to_paragraph를 비워둔다.
+
+    문단 9.9는 어떤 Subsection에도 없으므로 문단 우선(시도2) 매칭이 실패하고
+    절 패턴(시도3)으로 폴백 해소된다. 이때 to_paragraph가 "9.9"로 잘못 채워지면 안 된다.
+    """
+    graph = _make_graph()
+    graph.edges = [OntologyEdge(
+        from_id="gaap-ch6-s1-최초인식", to_id="",
+        edge_type="REFERENCES", unresolved_target="제2절 문단 9.9",
+    )]
+    resolved = resolve_edges(graph)
+    assert resolved.edges[0].to_id == "gaap-ch6-s2"
+    assert resolved.edges[0].to_paragraph == ""
+
+
+def test_resolve_subsection_sets_to_paragraph():
+    """Subsection으로 해소된 엣지는 to_paragraph를 정상적으로 채운다."""
+    graph = _make_graph()
+    graph.edges = [OntologyEdge(
+        from_id="gaap-ch6-s2", to_id="",
+        edge_type="REFERENCES", unresolved_target="문단 6.4",
+    )]
+    resolved = resolve_edges(graph)
+    assert resolved.edges[0].to_id == "gaap-ch6-s1-최초인식"
+    assert resolved.edges[0].to_paragraph == "6.4"
+
+
 def test_resolve_failure_records_unresolved():
     graph = _make_graph()
     graph.edges = [OntologyEdge(


### PR DESCRIPTION
## 개요

`resolver.py`의 `resolve_edges()`가 참조를 절(Section)·장(Standard)으로 해소했을 때도, 원문 텍스트에 문단 번호 패턴이 섞여 있으면 `to_paragraph`를 잘못 채우던 논리 오류를 수정합니다. (#69)

RAG 탐색 단계에서 이 `to_paragraph`를 신뢰해 해당 Section에 존재하지 않는 문단을 검색하면 빈 결과가 반환되거나 잘못된 컨텍스트가 주입되는 문제가 있었습니다.

---

## 변경 사항

### 수정

- **`src/db/ontology/resolver.py`** — `resolve_edges()`에 `node_type_map`을 추가하고, `to_paragraph`를 해소된 노드가 `Subsection`일 때만 설정하도록 조건 추가

### 테스트

- **`tests/unit/ontology/test_resolver.py`** — 회귀 방지 테스트 2건 추가
  - `test_resolve_section_does_not_set_to_paragraph` — 절로 폴백 해소 시 `to_paragraph`가 비는지 검증
  - `test_resolve_subsection_sets_to_paragraph` — Subsection 해소 시 `to_paragraph`가 정상 설정되는지 검증

---

## 원인 분석

기존 코드는 "절·장으로만 해소된 경우 `_PARA_RE`가 매칭되지 않으므로 `to_paragraph`는 빈 문자열이 된다"고 가정했으나, 실제로는 `norm`에 문단 패턴이 섞여 있으면(`"제2절 문단 6.4"` → `"제2절문단6.4"`) `_PARA_RE`가 `6.4`를 매칭합니다.

해당 문단이 그래프에 **존재할 때**는 해소 순서상(문단 우선) Subsection으로 매핑되지만, **존재하지 않을 때**는 절(시도3)로 폴백 해소되면서 `to_paragraph`에 실제로는 없는 문단 번호가 채워집니다.

```python
# 수정 전
m = _PARA_RE.search(norm)
to_para = m.group(1) if m else ""

# 수정 후
m = _PARA_RE.search(norm)
to_para = m.group(1) if (m and node_type_map.get(target_id) == "Subsection") else ""
```

---

## 체크리스트

- [x] resolver 단위 테스트 전체 통과 (7/7)
- [x] 절/장 해소 시 `to_paragraph` 미설정 검증
- [x] Subsection 해소 시 `to_paragraph` 정상 설정 검증

Closes #69
