### PR TITLE
test: resolver 범위 표기 prefix 불일치 회귀 테스트 추가 (#70)

### DIFF
--- a/src/db/ontology/resolver.py
+++ b/src/db/ontology/resolver.py
@@ -29,10 +29,9 @@ def _para_prefix(p: str) -> str:
 def _expand_range_target(target: str, paragraphs_in_order: list[str]) -> list[str] | None:
     """범위 표기 unresolved_target을 그래프의 paragraphs에 맞춰 개별 paragraph 번호 목록으로 확장.
 
-    예: "문단 6.8의2~6.11" → ["6.8의2", "6.9", "6.10", "6.11"]
-    같은 종류(본문/실무지침/결론/사례) 안에서만 확장한다. 시작·끝의 prefix가 다르거나
-    그래프에서 찾을 수 없으면 None 반환. None 반환 시 resolver는 unresolved_target을
-    원문 그대로 유지해 수동 확인이 가능하게 한다.
+    예: "문단 6.8의2~6.11" → ["6.8의2", "6.9", "6.10", "6.11"] 같은 종류(본문/실무지침/결론/사례) 안에서만 확장한다. 
+    시작·끝의 prefix가 다르거나 그래프에서 찾을 수 없으면 None 반환
+    None 반환 시 resolver는 unresolved_target을 원문 그대로 유지해 수동 확인이 가능하게 한다.
     """
     cleaned = re.sub(r'^문단\s*', '', target.strip())
     parts = _RANGE_SEP_RE.split(cleaned)

--- a/tests/unit/ontology/test_resolver.py
+++ b/tests/unit/ontology/test_resolver.py
@@ -1,5 +1,5 @@
 from src.db.ontology.models import OntologyGraph, OntologyNode, OntologyEdge
-from src.db.ontology.resolver import build_lookup, resolve_edges
+from src.db.ontology.resolver import build_lookup, resolve_edges, _expand_range_target
 
 
 def _make_graph() -> OntologyGraph:
@@ -48,3 +48,66 @@ def test_resolve_failure_records_unresolved():
     resolved = resolve_edges(graph)
     assert resolved.edges[0].to_id == ""
     assert resolved.edges[0].unresolved_target == "제8장 문단 8.2"
+
+
+# --- 범위 표기 확장 ---------------------------------------------------
+# start/end의 prefix(실·결·사례)가 다르면 확장하지 않고 None을 반환해
+# 존재하지 않는 문단 번호(예: "실6.67")가 만들어지는 것을 막는다.
+
+def test_expand_range_same_prefix_expands_inclusive():
+    # 같은 종류(본문)의 연속 범위는 끝 번호까지 포함해 확장한다.
+    paras = ["6.8의2", "6.9", "6.10", "6.11"]
+    assert _expand_range_target("문단 6.8의2~6.11", paras) == paras
+
+
+def test_expand_range_practice_prefix_expands():
+    # 실무지침(실) prefix가 양쪽 모두 일치하면 정상 확장한다.
+    paras = ["실6.66", "실6.67"]
+    assert _expand_range_target("문단 실6.66~실6.67", paras) == paras
+
+
+def test_expand_range_prefix_mismatch_returns_none():
+    # 시작은 "실6.66", 끝은 prefix 없는 "6.67"인 경우.
+    # start prefix를 그대로 끌어다 "실6.67"을 만들면 안 되므로 None을 반환한다.
+    paras = ["실6.66", "6.67"]
+    assert _expand_range_target("문단 실6.66~6.67", paras) is None
+
+
+def test_resolve_range_prefix_mismatch_keeps_unresolved():
+    # _expand_range_target가 None이면 resolver는 원문을 그대로 남겨 수동 확인이 가능하게 하고
+    # 잘못된 부분의 매핑 엣지를 만들지 않는다.
+    graph = OntologyGraph(nodes=[
+        OntologyNode(id="gaap-ch6-s1-실무지침", node_type="Subsection",
+                     title="실무지침", paragraphs=["실6.66"]),
+        OntologyNode(id="gaap-ch6-s1-본문", node_type="Subsection",
+                     title="본문", paragraphs=["6.67"]),
+    ])
+    graph.edges = [OntologyEdge(
+        from_id="gaap-ch6-s1-실무지침", to_id="",
+        edge_type="REFERENCES", unresolved_target="문단 실6.66~6.67",
+    )]
+    resolved = resolve_edges(graph)
+    assert len(resolved.edges) == 1
+    assert resolved.edges[0].to_id == ""
+    assert resolved.edges[0].unresolved_target == "문단 실6.66~6.67"
+
+
+def test_resolve_range_splits_into_multiple_edges():
+    # 동일 prefix 범위는 paragraph마다 개별 REFERENCES 엣지로 분리된다.
+    graph = OntologyGraph(nodes=[
+        OntologyNode(id="gaap-ch6-s1-src", node_type="Subsection",
+                     title="출처", paragraphs=["6.8"]),
+        OntologyNode(id="gaap-ch6-s1-a", node_type="Subsection",
+                     title="a", paragraphs=["6.9"]),
+        OntologyNode(id="gaap-ch6-s1-b", node_type="Subsection",
+                     title="b", paragraphs=["6.10"]),
+    ])
+    graph.edges = [OntologyEdge(
+        from_id="gaap-ch6-s1-src", to_id="",
+        edge_type="REFERENCES", unresolved_target="문단 6.9~6.10",
+    )]
+    resolved = resolve_edges(graph)
+    to_ids = sorted(e.to_id for e in resolved.edges)
+    assert to_ids == ["gaap-ch6-s1-a", "gaap-ch6-s1-b"]
+    assert all(e.unresolved_target == "" for e in resolved.edges)
+    assert {e.to_paragraph for e in resolved.edges} == {"6.9", "6.10"}


### PR DESCRIPTION
## 개요

이슈 #70 대응. 범위형 참조(`실6.66∼6.67` 등)에서 시작·끝의 prefix(`실`/`결`/없음)가
불일치할 때 존재하지 않는 문단 번호(`실6.67`)가 만들어지던 버그에 대한 회귀 테스트를 추가합니다.

---

## 배경

- 이슈 #70은 커밋 `81a86e3` 시점의 `md_parser._expand_range()`를 대상으로 제기되었습니다.
- 이후 `b30e008`("범위 표기 확장 로직 이관")에서 해당 로직이 `resolver._expand_range_target()`로
  이관되며 **prefix 불일치 가드가 함께 도입**되어, 버그 자체는 이미 해소된 상태입니다.
- 그러나 범위 확장 동작에 대한 테스트가 전무해 회귀 위험이 있었습니다. 동작을 고정하기 위해 테스트를 추가합니다.

---

## 변경 사항

### 추가

- **`tests/unit/ontology/test_resolver.py`** — 범위 확장 회귀 테스트 5건
  - `test_expand_range_same_prefix_expands_inclusive` — 동일 prefix(본문) 범위 확장
  - `test_expand_range_practice_prefix_expands` — 실무지침(`실`) prefix 범위 확장
  - `test_expand_range_prefix_mismatch_returns_none` — **#70 핵심 시나리오** (prefix 불일치 → `None`)
  - `test_resolve_range_prefix_mismatch_keeps_unresolved` — resolver가 불일치 시 원문 유지
  - `test_resolve_range_splits_into_multiple_edges` — 동일 prefix 범위를 개별 엣지로 분리

> 프로덕션 코드 변경 없음 (테스트 전용).

---

## 동작 검증

- `_expand_range_target("문단 실6.66~6.67", ["실6.66", "6.67"])` → `None` (잘못된 `실6.67` 미생성)
- 확장 실패 시 resolver는 `unresolved_target` 원문을 유지해 수동 확인이 가능

---

## 체크리스트

- [x] 단위 테스트 통과 (`test_resolver.py` 10/10)
- [ ] 코드 리뷰

Closes #70
