### PR TITLE
feat: 온톨로지 그래프 청킹 모듈 구현 (#111)

### DIFF
--- a/src/db/ontology/chunker.py
+++ b/src/db/ontology/chunker.py
@@ -1,0 +1,182 @@
+"""온톨로지 그래프 → 검색 청크 변환 모듈 (FUNC-002/003)
+
+청킹(chunking)이란?
+    - 긴 문서를 검색·임베딩에 적합한 작은 조각(청크)으로 나누는 작업입니다.
+    - 이 프로젝트는 PDF를 파싱(FUNC-001)하고, 그 결과를 온톨로지 그래프로 구조화한 뒤, 그래프의 노드를 청크로 변환해 pgvector에 적재(FUNC-003)합니다.
+
+설계 결정:
+    1. 청킹 단위 — 온톨로지 노드 기반.
+       `md_parser`가 Subsection을 "임베딩 단위"로 설계했고, 각 노드의 `content`가 이미 절·소절 경계로 분할되어 있다.
+       content를 보유한 모든 노드(Subsection + 직속 문단이 있는 Section)를 청크화한다.
+       content가 없는 Standard·Section 노드는 자연스럽게 제외된다.
+       → 노드의 ontology_node_id가 그대로 청크 메타데이터에 실려, 고아 청크가 없다.
+    2. chunk_id 규약 — 결정적 ID.
+       분할되지 않은 노드는 chunk_id == node.id (노드 ↔ 청크 1:1).
+       토큰 한도 초과로 분할되면 동일 node.id를 공유하며 "-0", "-1" 순번을 붙인다.
+       실행 시각·랜덤을 쓰지 않으므로 동일 입력 재실행 시 동일 ID가 나와, `index_documents`의 ON CONFLICT upsert가 멱등하게 동작한다.
+    3. 토큰 한도 초과 처리 — 인덱싱 단계는 EMBEDDING_MAX_TOKENS(8192) 초과 청크를 IX-201로 스킵(데이터 손실)한다.
+        청킹 단계에서 문단→문장→문자 순으로 경계를 낮춰가며 분할해 손실을 막는다. 분할 조각들은 동일 ontology_node_id를 유지한다.
+    4. metadata 전파 — standard_type·chapter는 Standard 노드 기준으로 모든 청크에 전파한다(Subsection·Section 노드 자체는 이 두 필드가 비어 있기 때문).
+        source_path(파서 메타데이터)는 ChunkMetadata의 extra 필드로 싣는다.
+"""
+import re
+from collections.abc import Callable
+
+from src.db.ontology.models import OntologyGraph
+from src.models.schemas import ChunkMetadata, RetrievedChunk
+from src.utils.config import EMBEDDING_MAX_TOKENS
+from src.utils.embedding import count_tokens
+from src.utils.exception import OntologyParsingError
+from src.utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+# 문장 경계 분할용 — 마침표·물음표·느낌표(한글/전각 포함) 뒤의 공백에서 끊는다.
+_SENTENCE_RE = re.compile(r"(?<=[.。!?！？])\s+")
+
+
+def _greedy_pack(units: list[str], sep: str, max_tokens: int, count: Callable[[str], int]) -> list[str]:
+    """조각을 순서대로 이어붙이되, 토큰 한도를 넘기 직전까지 한 덩어리로 묶는다.
+
+    그리디(greedy) 방식: 버퍼에 다음 조각을 더했을 때 한도를 넘으면, 현재 버퍼를 하나의 청크로 확정하고 새 버퍼를 시작한다.
+    단일 조각이 이미 한도를 넘는 경우는 여기서 쪼개지 못하고 그대로 반환되므로, 호출측에서 더 작은 경계로 재분할한다.
+    """
+    packed: list[str] = []
+    buffer = ""
+    # 조각을 순서대로 이어붙인다.
+    for unit in units:
+        if not unit:
+            continue
+        candidate = f"{buffer}{sep}{unit}" if buffer else unit
+        if buffer and count(candidate) > max_tokens:
+            packed.append(buffer)
+            buffer = unit
+        else:
+            buffer = candidate
+    # 마지막 버퍼를 추가한다.
+    if buffer:
+        packed.append(buffer)
+    return packed
+
+
+def _hard_split(text: str, max_tokens: int, count: Callable[[str], int]) -> list[str]:
+    """문장으로도 나눌 수 없는 한 덩어리를 문자 단위 이분탐색으로 강제 분할한다.
+
+    토큰 한도 이하가 되는 최대 길이의 앞부분을 이분탐색으로 찾아 잘라내고, 남은 뒷부분을 재귀적으로 처리한다.
+    의미 경계를 무시하는 최후의 fallback이므로 한 문단/문장이 단독으로 8192 토큰을 넘는 극단적 입력에서만 호출된다.
+    """
+    result: list[str] = []
+    remaining = text
+    while count(remaining) > max_tokens:    # 토큰 한도를 넘으면, 이분탐색으로 쪼갠다.
+        lo, hi = 1, len(remaining)
+        while lo < hi:  # 이분탐색
+            mid = (lo + hi + 1) // 2
+            if count(remaining[:mid]) <= max_tokens:  # 토큰 한도 이하이면 앞부분을 더 포함
+                lo = mid
+            else:
+                hi = mid - 1
+        result.append(remaining[:lo])
+        remaining = remaining[lo:]
+    # 마지막 버퍼를 추가한다.
+    if remaining:
+        result.append(remaining)
+    return result
+
+
+def _split_content(content: str, max_tokens: int, count: Callable[[str], int]) -> list[str]:
+    """노드 content를 토큰 한도 이하 조각들로 분할한다.
+
+    경계 우선순위: 줄(문단) → 문장 → 문자.
+    대부분의 노드는 한도 이하라 분할 없이 [content] 그대로 반환된다.
+    """
+    # 한도 이하이면 분할 없이 [content] 그대로 반환
+    if count(content) <= max_tokens:
+        return [content]
+
+    pieces: list[str] = []
+    # 1차: 줄 경계(회계 마크다운에서 각 H4 문단이 별도 줄)로 묶는다.
+    for block in _greedy_pack(content.split("\n"), "\n", max_tokens, count):
+        if count(block) <= max_tokens:
+            pieces.append(block)
+            continue
+        # 2차: 한 줄이 여전히 한도를 넘으면 문장 경계로 묶는다.
+        for sentence in _greedy_pack(_SENTENCE_RE.split(block), " ", max_tokens, count):
+            if count(sentence) <= max_tokens:
+                pieces.append(sentence)
+            else:
+                # 3차: 한 문장조차 한도를 넘으면 문자 단위로 강제 분할한다.
+                pieces.extend(_hard_split(sentence, max_tokens, count))
+
+    # 분할 과정에서 생긴 공백-only 조각은 버린다.
+    return [p for p in pieces if p.strip()]
+
+
+def chunk_graph(
+    graph: OntologyGraph,
+    *,
+    document_id: str | None = None,
+    source_path: str | None = None,
+    max_tokens: int = EMBEDDING_MAX_TOKENS,
+    token_counter: Callable[[str], int] = count_tokens,
+) -> list[RetrievedChunk]:
+    """온톨로지 그래프를 검색 청크 리스트로 변환한다.
+
+    :param graph: build_graph(또는 parse_markdown) 결과 그래프
+    :param document_id: 기준서 단위 식별자. None이면 Standard 노드의 id를 사용한다(장 단위).
+    :param source_path: 원본 파일 경로(파서 메타데이터). 지정 시 ChunkMetadata extra 필드로 전파.
+    :param max_tokens: 청크 1개의 토큰 상한. 초과 노드는 분할된다(기본 EMBEDDING_MAX_TOKENS).
+    :param token_counter: 토큰 수 계산 함수. 기본은 KURE-v1 토크나이저. 테스트에서 모델 로드 없이 가벼운 함수를 주입할 수 있도록 인자로 노출한다.
+    :return: RetrievedChunk 리스트. 각 청크는 metadata.ontology_node_id를 보유하고 score=0.0.
+    :raises OntologyParsingError: content 노드가 있는데 document_id를 결정할 수 없을 때 (OT-103)
+    """
+    # content를 가진 노드만 청크화 대상. (Standard·직속 본문 없는 Section은 제외)
+    content_nodes = [n for n in graph.nodes if (n.content or "").strip()]
+    if not content_nodes:
+        # 빈 문서·구조만 있는 그래프 → 적재할 청크 없음. 정상적으로 빈 리스트 반환.
+        logger.info("청킹 대상 노드 없음 — 빈 청크 리스트 반환")
+        return []
+
+    # standard_type·chapter는 Standard 노드 기준으로 전 청크에 전파한다.
+    standard = next((n for n in graph.nodes if n.node_type == "Standard"), None)
+    # document_id가 지정되지 않았으면 Standard 노드의 id를 사용한다.
+    if document_id is None:    
+        # Standard 노드가 없으면 document_id를 결정할 수 없어 오류 발생
+        if standard is None:
+            raise OntologyParsingError(
+                "document_id가 지정되지 않았고 그래프에 Standard 노드도 없어 식별자를 결정할 수 없습니다."
+            )
+        document_id = standard.id
+    # standard_type, chapter는 Standard 노드 기준으로 전 청크에 전파한다.
+    standard_type = (standard.standard_type or None) if standard else None
+    chapter = (standard.chapter or None) if standard else None
+
+    chunks: list[RetrievedChunk] = []
+    for node in content_nodes:
+        pieces = _split_content(node.content.strip(), max_tokens, token_counter)
+        is_single = len(pieces) == 1
+        for seq, piece in enumerate(pieces):
+            # 분할되지 않은 노드는 chunk_id == node.id (노드 ↔ 청크 1:1).
+            # 분할된 노드는 동일 node.id에 순번을 붙여 멱등성과 매핑을 동시에 만족한다.
+            chunk_id = node.id if is_single else f"{node.id}-{seq}"
+            metadata_kwargs: dict = {
+                "ontology_node_id": node.id,
+                "node_type": node.node_type,
+                "standard_type": standard_type,
+                "chapter": chapter,
+            }
+            if source_path:
+                metadata_kwargs["source_path"] = source_path  # extra="allow" 비정형 필드
+            chunks.append(
+                RetrievedChunk(
+                    chunk_id=chunk_id,
+                    document_id=document_id,
+                    content=piece,
+                    score=0.0,
+                    metadata=ChunkMetadata(**metadata_kwargs),
+                )
+            )
+
+    logger.info(
+        f"청킹 완료: document_id={document_id}, 노드 {len(content_nodes)}개 → 청크 {len(chunks)}개"
+    )
+    return chunks

--- a/tests/unit/ontology/test_chunker.py
+++ b/tests/unit/ontology/test_chunker.py
@@ -1,0 +1,267 @@
+"""chunker.chunk_graph 단위 테스트
+
+검증 항목:
+  - 노드 매핑 정합성 — content 노드 ↔ 청크, 모든 청크가 ontology_node_id 보유 (고아 0건)
+  - 토큰 한도 분할 — 초과 노드가 분할되고 조각들이 동일 node_id 공유 + 순번
+  - chunk_id 결정성 — 동일 입력 재실행 시 동일 ID
+  - 빈 문서 처리 — content 노드가 없으면 빈 리스트
+  - metadata 전파 — standard_type·chapter(Standard 기준)·source_path(extra)
+
+토큰 카운터는 모델 로드를 피하기 위해 "공백으로 나눈 단어 수"를 쓰는 가벼운 함수를 주입한다.
+"""
+import pytest
+
+from src.db.ontology.chunker import chunk_graph
+from src.db.ontology.models import OntologyGraph, OntologyNode
+from src.models.schemas import RetrievedChunk
+from src.utils.exception import OntologyParsingError
+
+
+def _word_count(text: str) -> int:
+    """모델 없이 쓰는 가벼운 토큰 카운터 — 공백 기준 단어 수."""
+    return len(text.split())
+
+
+def _sample_graph() -> OntologyGraph:
+    """Standard 1 + content Section 1 + content 없는 Section 1 + Subsection 2 구성."""
+    graph = OntologyGraph()
+    graph.nodes.append(
+        OntologyNode(
+            id="gaap-ch6",
+            node_type="Standard",
+            name="제6장 금융자산·금융부채",
+            standard_type="GAAP",
+            chapter="6",
+        )
+    )
+    # 직속 문단이 있는 Section → 청크화 대상
+    graph.nodes.append(
+        OntologyNode(
+            id="gaap-ch6-s1",
+            node_type="Section",
+            title="제1절 공통사항",
+            order=1,
+            content="6.3 제2절~제4절에서 정하지 않은 사항은 이 절의 원칙을 적용한다.",
+        )
+    )
+    # content 없는 Section → 청크화 제외
+    graph.nodes.append(
+        OntologyNode(
+            id="gaap-ch6-s2",
+            node_type="Section",
+            title="제2절 인식",
+            order=2,
+            content="",
+        )
+    )
+    graph.nodes.append(
+        OntologyNode(
+            id="gaap-ch6-s1-최초인식",
+            node_type="Subsection",
+            title="금융상품의 최초인식",
+            order=1,
+            content="6.4 금융자산이나 금융부채는 계약당사자가 되는 때에만 인식한다.",
+        )
+    )
+    graph.nodes.append(
+        OntologyNode(
+            id="gaap-ch6-s2-측정",
+            node_type="Subsection",
+            title="후속측정",
+            order=1,
+            content="6.5 최초인식 후 금융자산은 상각후원가로 측정한다.",
+        )
+    )
+    return graph
+
+
+def test_returns_retrieved_chunks():
+    """결과물이 RetrievedChunk 타입인지 확인"""
+    chunks = chunk_graph(_sample_graph(), token_counter=_word_count)
+    assert all(isinstance(c, RetrievedChunk) for c in chunks)
+
+
+def test_only_content_nodes_become_chunks():
+    """content 있는 노드만 청크가 되는지 확인"""
+    # content 있는 노드: Section 1 + Subsection 2 = 3개. Standard·빈 Section은 제외.
+    chunks = chunk_graph(_sample_graph(), token_counter=_word_count)
+    assert len(chunks) == 3
+    node_ids = {c.metadata.ontology_node_id for c in chunks}
+    assert node_ids == {"gaap-ch6-s1", "gaap-ch6-s1-최초인식", "gaap-ch6-s2-측정"}
+
+
+def test_no_orphan_chunks():
+    """모든 청크가 ontology_node_id를 보유하는지 확인 (고아 0건)"""
+    chunks = chunk_graph(_sample_graph(), token_counter=_word_count)
+    assert chunks
+    assert all(c.metadata.ontology_node_id for c in chunks)
+
+
+def test_score_is_zero():
+    """모든 청크의 score가 0.0인지 확인"""
+    chunks = chunk_graph(_sample_graph(), token_counter=_word_count)
+    assert all(c.score == 0.0 for c in chunks)
+
+
+def test_unsplit_chunk_id_equals_node_id():
+    """분할되지 않은 노드는 chunk_id == node.id (노드 ↔ 청크 1:1)인지 확인"""
+    chunks = chunk_graph(_sample_graph(), token_counter=_word_count)
+    for c in chunks:
+        assert c.chunk_id == c.metadata.ontology_node_id
+
+
+def test_document_id_defaults_to_standard_id():
+    """document_id가 없으면 Standard 노드의 id를 사용"""
+    chunks = chunk_graph(_sample_graph(), token_counter=_word_count)
+    assert all(c.document_id == "gaap-ch6" for c in chunks)
+
+
+def test_document_id_override():
+    """document_id를 지정하면 해당 id를 사용"""
+    chunks = chunk_graph(_sample_graph(), document_id="custom-doc", token_counter=_word_count)
+    assert all(c.document_id == "custom-doc" for c in chunks)
+
+
+def test_metadata_propagation():
+    """metadata 전파 테스트 - standard_type·chapter·source_path"""
+    chunks = chunk_graph(
+        _sample_graph(), source_path="data/회계_sample.pdf", token_counter=_word_count
+    )
+    sample = chunks[0]
+    # standard_type·chapter는 Standard 노드 기준으로 전파된다.
+    assert sample.metadata.standard_type == "GAAP"
+    assert sample.metadata.chapter == "6"
+    # node_type은 해당 노드 기준.
+    assert sample.metadata.node_type in {"Section", "Subsection"}
+    # source_path는 extra 필드로 실린다.
+    assert sample.metadata.model_extra.get("source_path") == "data/회계_sample.pdf"
+
+
+def test_source_path_omitted_when_not_given():
+    """source_path가 주어지지 않으면 extra에 포함되지 않음"""
+    chunks = chunk_graph(_sample_graph(), token_counter=_word_count)
+    assert "source_path" not in (chunks[0].metadata.model_extra or {})
+
+
+def test_empty_graph_returns_empty_list():
+    """빈 그래프는 빈 리스트를 반환"""
+    assert chunk_graph(OntologyGraph(), token_counter=_word_count) == []
+
+
+def test_graph_without_content_nodes_returns_empty_list():
+    """content 노드가 없는 그래프는 빈 리스트를 반환"""
+    # Standard 노드만 있고 content 노드가 없는 경우 → 빈 리스트 (에러 아님).
+    graph = OntologyGraph()
+    graph.nodes.append(
+        OntologyNode(id="gaap-ch6", node_type="Standard", standard_type="GAAP", chapter="6")
+    )
+    assert chunk_graph(graph, token_counter=_word_count) == []
+
+
+def test_missing_standard_raises_when_document_id_absent():
+    """content 노드는 있는데 Standard도 없고 document_id도 안 주면 식별자를 못 정한다."""
+    graph = OntologyGraph()
+    graph.nodes.append(
+        OntologyNode(id="orphan-sub", node_type="Subsection", title="x", content="내용 있음")
+    )
+    with pytest.raises(OntologyParsingError):
+        chunk_graph(graph, token_counter=_word_count)
+
+
+def test_missing_standard_ok_when_document_id_given():
+    """Standard가 없어도 document_id가 있으면 chunk_graph가 정상 동작"""
+    graph = OntologyGraph()
+    graph.nodes.append(
+        OntologyNode(id="orphan-sub", node_type="Subsection", title="x", content="내용 있음")
+    )
+    chunks = chunk_graph(graph, document_id="manual-id", token_counter=_word_count)
+    assert len(chunks) == 1
+    assert chunks[0].document_id == "manual-id"
+    # Standard가 없으면 standard_type·chapter는 None.
+    assert chunks[0].metadata.standard_type is None
+    assert chunks[0].metadata.chapter is None
+
+
+def test_oversized_node_is_split_by_paragraph():
+    """노드가 토큰 한도를 초과하면 문단 단위로 분할되는지 확인"""
+    # max_tokens=5(단어 5개) 한도. 4문단 × 단어 4개씩 = 분할 발생.
+    graph = OntologyGraph()
+    graph.nodes.append(
+        OntologyNode(id="gaap-ch6", node_type="Standard", standard_type="GAAP", chapter="6")
+    )
+    content = "\n".join(
+        [
+            "가 나 다 라",   # 4 단어
+            "마 바 사 아",
+            "자 차 카 타",
+            "파 하 거 너",
+        ]
+    )
+    graph.nodes.append(
+        OntologyNode(id="gaap-ch6-big", node_type="Subsection", title="큰절", content=content)
+    )
+    chunks = chunk_graph(graph, max_tokens=5, token_counter=_word_count)
+    # 한 청크에 한 문단(4단어)씩 — 두 문단을 합치면 8 > 5라 묶이지 못한다.
+    assert len(chunks) == 4
+    # 분할 조각은 동일 ontology_node_id를 공유하고 순번이 붙는다.
+    assert all(c.metadata.ontology_node_id == "gaap-ch6-big" for c in chunks)
+    assert [c.chunk_id for c in chunks] == [
+        "gaap-ch6-big-0",
+        "gaap-ch6-big-1",
+        "gaap-ch6-big-2",
+        "gaap-ch6-big-3",
+    ]
+    # 모든 조각이 한도 이하.
+    assert all(_word_count(c.content) <= 5 for c in chunks)
+
+
+def test_split_preserves_no_data_loss():
+    """분할 후에도 전체 단어가 보존되어야 한다 (손실 없음)"""
+    graph = OntologyGraph()
+    graph.nodes.append(
+        OntologyNode(id="d", node_type="Standard", standard_type="GAAP", chapter="6")
+    )
+    words = [f"w{i}" for i in range(20)]
+    graph.nodes.append(
+        OntologyNode(id="d-node", node_type="Subsection", title="t", content=" ".join(words))
+    )
+    chunks = chunk_graph(graph, max_tokens=3, token_counter=_word_count)
+    recombined = " ".join(c.content for c in chunks).split()
+    assert recombined == words
+
+
+def test_hard_split_when_single_unit_exceeds_limit():
+    """줄·문장으로 못 나누는 한 덩어리(공백 없는 긴 문자열)는 문자 단위로 강제 분할"""
+    graph = OntologyGraph()
+    graph.nodes.append(
+        OntologyNode(id="d", node_type="Standard", standard_type="GAAP", chapter="6")
+    )
+    # 공백이 없으면 _word_count는 1을 반환하므로, 문자 수 기반 카운터로 강제 분할을 유도한다.
+    long_text = "가" * 100
+    graph.nodes.append(
+        OntologyNode(id="d-long", node_type="Subsection", title="t", content=long_text)
+    )
+    chunks = chunk_graph(graph, max_tokens=30, token_counter=len)
+    assert len(chunks) >= 4
+    assert all(len(c.content) <= 30 for c in chunks)
+    # 문자 보존 — 강제 분할이어도 손실 없음.
+    assert "".join(c.content for c in chunks) == long_text
+
+
+def test_chunk_id_determinism():
+    """동일 입력 재실행 → 동일 chunk_id (upsert 멱등성의 전제) 확인"""
+    first = chunk_graph(_sample_graph(), token_counter=_word_count)
+    second = chunk_graph(_sample_graph(), token_counter=_word_count)
+    assert [c.chunk_id for c in first] == [c.chunk_id for c in second]
+    # 분할 케이스도 결정적인지 확인.
+    graph = OntologyGraph()
+    graph.nodes.append(OntologyNode(id="d", node_type="Standard", standard_type="GAAP", chapter="6"))
+    graph.nodes.append(
+        OntologyNode(
+            id="d-n", node_type="Subsection", title="t",
+            content="\n".join(["가 나 다 라", "마 바 사 아", "자 차 카 타"]),
+        )
+    )
+    a = chunk_graph(graph, max_tokens=5, token_counter=_word_count)
+    b = chunk_graph(graph, max_tokens=5, token_counter=_word_count)
+    assert [c.chunk_id for c in a] == [c.chunk_id for c in b]


### PR DESCRIPTION
## 개요

`ParsedDocument`(+ 온톨로지 그래프)로부터 검색 청크(`RetrievedChunk`)를 생성하는 **청킹 모듈**을 구현합니다. dev에는 청크를 소비하는 코드(searcher·reranker·vector_store·ontology_bridge)만 있고 **생산하는 코드가 없던** 공백을 메웁니다. 온톨로지 노드를 청킹 단위로 삼아 모든 청크가 `ontology_node_id`를 보유하도록 하여, 인덱싱(FUNC-003)·검색·온톨로지 매핑(#72/#80)이 자연스럽게 이어지도록 합니다.

Closes #111

---

## 변경 사항

### 신규 구현

- **`src/db/ontology/chunker.py`** — `chunk_graph(graph, *, document_id, source_path, max_tokens, token_counter) -> list[RetrievedChunk]`. 온톨로지 그래프 → 청크 변환 진입점 및 토큰 한도 분할 로직
- **`tests/unit/ontology/test_chunker.py`** — 단위 테스트 17 케이스

### 수정

- 없음 (기존 인터페이스를 소비만 하는 신규 모듈이라 기존 코드 변경 없음)

---

## 아키텍처

### 처리 흐름

```text
OntologyGraph (build_graph 결과)
    │
    ▼
content 보유 노드 필터링  (Standard·직속 본문 없는 Section 제외)
    │
    ▼
노드별 _split_content  ── 토큰 ≤ 한도 ──→ 단일 청크 (chunk_id = node.id)
    │                  └─ 토큰 > 한도 ──→ 문단→문장→문자 경계 분할 (chunk_id = node.id-순번)
    ▼
RetrievedChunk 리스트  (metadata.ontology_node_id 포함, score=0.0)
```

### 주요 설계 결정 (이슈 #111 "구현 전 확정" 항목)

| 항목 | 결정 | 근거 |
|------|------|------|
| **청킹 단위** | content를 가진 모든 노드 (Subsection + 직속 본문 Section) | `md_parser`가 Subsection을 "임베딩 단위"로 설계. 실데이터 1,093노드 분석상 content를 가진 Section 6개의 직속 본문이 Subsection과 독립 → "Subsection만"으로는 본문 손실 발생. content 없는 Standard·Section은 자연 제외 |
| **chunk_id 규약** | 비분할: `node.id` / 분할: `node.id-순번` | 결정적 ID. 실행 시각·랜덤 미사용 → 동일 입력 재실행 시 동일 ID → `index_documents` ON CONFLICT upsert 멱등 |
| **토큰 한도 초과 처리** | 문단(`\n`)→문장→문자(이분탐색) 경계로 분할 | 인덱싱 단계는 `EMBEDDING_MAX_TOKENS`(8192) 초과 청크를 IX-201로 **스킵(손실)**. 청킹 단계 분할로 손실 방지. 분할 조각은 동일 `ontology_node_id` 유지 |
| **document_id 규약** | Standard 노드 id (장 단위, 예: `gaap-ch6`) | 미지정 시 자동 결정. `document_id` 인자로 override 가능 |
| **metadata 전파** | `ontology_node_id`·`node_type`은 노드 기준, `standard_type`·`chapter`는 Standard 노드 기준, `source_path`는 extra 필드 | Subsection·Section 노드는 `standard_type`·`chapter`가 비어 있어 Standard에서 전파. `source_path`는 `ChunkMetadata(extra="allow")`로 수용 |
| **모듈 위치** | `src/db/ontology/chunker.py` | 온톨로지 그래프 소비자이므로 자연스러운 위치. ontology가 공용 `models.schemas`(RetrievedChunk)만 추가 import하여 의존 방향이 깔끔 |

---

## 검증

### 단위 테스트 (17/17 통과)

노드 매핑 정합성 · 고아 청크 0건 · 토큰 한도 분할(동일 node_id 공유 + 순번) · chunk_id 결정성 · 빈 문서 처리 · metadata 전파 · 분할 시 손실 없음 · 문자 단위 강제 분할(hard split). 모델 로드를 피하기 위해 토큰 카운터를 주입 가능하게 설계.

### 실데이터 적재 스모크 (제6장, 컨테이너 DB)

`gaap-ch6.json`(206노드) → content 200노드 → **200청크** 생성 후 `index_documents` 적재:

- 1차 적재: `status=success`, 200/200
- 2차 적재(멱등 재실행): `status=success`, DB 행 200 = 고유 chunk_id 200 → **중복 0, upsert 멱등 확인**
- `ontology_node_id` 누락 행(고아): **0건**
- metadata 전파: `ontology_node_id`·`standard_type=GAAP`·`chapter=6`·`source_path` 모두 DB 저장 확인

---

## 체크리스트

- [x] 단위 테스트 전체 통과 (17/17)
- [x] 실데이터 적재 스모크 — 200청크 `success`, upsert 멱등성·고아 0건 검증
- [x] `EMBEDDING_MAX_TOKENS` 초과 입력 분할 (손실 없음)
- [x] 모든 청크 `ontology_node_id` 보유 (#97 트랙 A "고아 청크 0건" 단언과 정합)
- [ ] #95 E2E ingest 경로(파싱 → 청킹 → 인덱싱) 연결 (후속 브랜치에서 진행 예정)
