### PR TITLE
Feature/main entry point — ingest/query E2E 진입점 (#95)

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,14 +20,44 @@ uv 사용을 권장합니다.
 uv sync
 ```
 
+### 2. 데이터베이스 기동
+
+pgvector 확장이 포함된 PostgreSQL을 docker-compose로 기동합니다.
+접속 정보는 `.env`(템플릿: `.env.example`)에서 읽습니다.
+
+```bash
+docker compose up -d database
+```
+
 ### 3. 실행
 
-에이전트 워크플로우를 실행합니다.
+진입점 `src/main.py`는 적재(`ingest`)와 질의(`query`) 두 경로를 제공합니다.
 
-<!-- 현재 구현되어 있지 않습니다. -->
+#### 문서 적재 (ingest)
+
+미리 빌드된 온톨로지 그래프(`data/ontology/*.json`)를 청킹·임베딩하여 pgvector에 적재합니다.
+
 ```bash
-uv run python src/main.py
+# data/ontology 전체 장을 적재 (검색기와 동일한 chunks 테이블에 저장)
+uv run python -m src.main ingest
+
+# 컬렉션을 비우고 새로 적재
+uv run python -m src.main ingest --reset
+
+# 단일 PDF에서 파싱 → 온톨로지 빌드 → 청킹·적재까지 전체 경로
+uv run python -m src.main ingest --pdf data/raw/제6장.pdf --standard-id gaap-ch6 --standard-type GAAP
 ```
+
+#### 질의 (query)
+
+적재된 데이터를 기반으로 워크플로(rewrite → search → rerank → evaluate → generate)를 실행해 답변과 인용을 출력합니다.
+
+```bash
+uv run python -m src.main query "금융자산의 최초 인식 시점은?"
+uv run python -m src.main query "리스 회계처리" --standard GAAP
+```
+
+> 컨테이너(`app`) 안에서 실행하려면 `docker compose exec app uv run python -m src.main ...` 형태로 호출합니다.
 
 ## 📂 프로젝트 구조
 

--- a/src/main.py
+++ b/src/main.py
@@ -1,0 +1,273 @@
+"""회계 기준서 RAG 시스템 실행 진입점
+
+두 가지 실행 경로를 단일 CLI로 제공한다.
+
+  1. ingest — 적재 경로
+     온톨로지 그래프 → 청킹(FUNC-002/003) → pgvector 적재(FUNC-003)
+     · 기본 소스: 미리 빌드된 온톨로지 JSON(data/ontology/*.json)
+     · --pdf/--md 지정 시: 파싱(FUNC-001) → 온톨로지 빌드(FUNC-002) → 청킹 → 적재까지 전체 경로
+     · 적재 대상 테이블은 검색기(searcher.py)가 조회하는 CHUNKS_TABLE("chunks")로 고정해
+       적재와 검색이 동일 테이블을 공유하도록 한다.
+
+  2. query — 질의 경로
+     질의 → LangGraph 워크플로(rewrite→search→rerank→evaluate→generate, FUNC-004~009)
+          → 답변/인용 출력
+     · HIL(human_review) interrupt 발생 시 대화형으로 승인/재작성을 받아 재개한다.
+
+사용 예:
+  uv run python -m src.main ingest                       # data/ontology 전 장 적재
+  uv run python -m src.main ingest --ontology-dir data/ontology --reset
+  uv run python -m src.main ingest --pdf data/raw/제6장.pdf --standard-id gaap-ch6 --standard-type GAAP
+  uv run python -m src.main query "금융자산의 최초 인식 시점은?"
+  uv run python -m src.main query "리스 회계처리" --standard GAAP
+"""
+import argparse
+import sys
+from pathlib import Path
+
+from dotenv import load_dotenv
+
+from src.db.connection import close_pool, init_pool
+from src.utils.config import CHUNKS_TABLE
+from src.utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+
+# ───────────────────────────── ingest 경로 ─────────────────────────────
+
+
+def _load_graph_from_json(path: Path):
+    """저장된 온톨로지 그래프 JSON을 OntologyGraph로 역직렬화한다."""
+    from src.db.ontology.models import OntologyGraph
+
+    return OntologyGraph.model_validate_json(path.read_text(encoding="utf-8"))
+
+
+def _build_graph_from_source(args):
+    """--pdf/--md 입력으로부터 온톨로지 그래프를 새로 빌드한다(FUNC-001→002).
+
+    PDF는 DoclingParser로 마크다운을 추출한 뒤 build_graph에 넘긴다.
+    LLM 엣지 추출이 포함되므로 OPENAI_API_KEY와 실행 시간이 필요하다.
+    """
+    from src.db.ontology.builder import build_graph
+
+    if args.md:
+        md_path = Path(args.md)
+    else:
+        # PDF → 마크다운(FUNC-001). build_graph는 마크다운 파일 경로를 입력으로 받으므로
+        # 파싱 결과 텍스트를 임시 .md로 저장해 전달한다.
+        from src.parse.parser import DoclingParser
+
+        pdf_path = Path(args.pdf)
+        logger.info(f"PDF 파싱 시작: {pdf_path}")
+        parsed = DoclingParser().parse(pdf_path)
+        md_path = pdf_path.with_suffix(".md")
+        md_path.write_text(parsed.text, encoding="utf-8")
+        logger.info(f"파싱 결과 마크다운 저장: {md_path}")
+
+    logger.info(f"온톨로지 빌드 시작(FUNC-002): {md_path}")
+    graph = build_graph(md_path, args.standard_id, args.standard_type)
+    return graph, str(md_path)
+
+
+def _index_graph(graph, source_path: str | None, collection: str) -> dict:
+    """온톨로지 그래프 한 개를 청킹 후 적재하고 IndexingResult를 dict로 반환한다."""
+    from src.db.ontology.chunker import chunk_graph
+    from src.db.vector_store import index_documents
+
+    chunks = chunk_graph(graph, source_path=source_path)
+    if not chunks:
+        logger.warning(f"청크가 비어 있어 적재를 건너뜁니다: source={source_path}")
+        return {"document_id": "", "chunk_count": 0, "status": "failed"}
+
+    result = index_documents(chunks, collection=collection)
+    return result.model_dump()
+
+
+def run_ingest(args) -> int:
+    """적재 경로 실행. 성공 시 0, 적재된 청크가 하나도 없으면 1을 반환한다."""
+    collection = args.collection
+    init_pool()
+    try:
+        if args.reset:
+            # 재적재 멱등성은 chunk_id 기반 upsert로도 보장되지만,
+            # --reset은 컬렉션을 비워 삭제된 노드의 잔여 청크까지 정리한다.
+            from src.db.vector_store import delete_collection
+
+            logger.info(f"컬렉션 초기화: {collection}")
+            delete_collection(collection)
+
+        # 적재 대상 그래프 목록을 (graph, source_path) 형태로 모은다.
+        targets: list[tuple[object, str | None]] = []
+        if args.pdf or args.md:
+            graph, source_path = _build_graph_from_source(args)
+            targets.append((graph, source_path))
+        else:
+            ontology_dir = Path(args.ontology_dir)
+            json_files = sorted(ontology_dir.glob("*.json"))
+            if not json_files:
+                logger.error(f"온톨로지 JSON을 찾지 못했습니다: {ontology_dir}")
+                return 1
+            logger.info(f"온톨로지 JSON {len(json_files)}개 적재 시작: {ontology_dir}")
+            for jf in json_files:
+                targets.append((_load_graph_from_json(jf), str(jf)))
+
+        total_chunks = 0
+        summaries: list[dict] = []
+        for graph, source_path in targets:
+            result = _index_graph(graph, source_path, collection)
+            total_chunks += result["chunk_count"]
+            summaries.append(result)
+            print(
+                f"  - {result['document_id'] or source_path}: "
+                f"{result['chunk_count']}청크 ({result['status']})"
+            )
+
+        print(
+            f"\n적재 완료: 문서 {len(summaries)}건, 총 {total_chunks}청크 → 테이블 '{collection}'"
+        )
+        return 0 if total_chunks > 0 else 1
+    finally:
+        close_pool()
+
+
+# ───────────────────────────── query 경로 ─────────────────────────────
+
+
+def _prompt_human_decision(payload: dict) -> dict:
+    """human_review interrupt 페이로드를 보여주고 사용자 결정을 받는다.
+
+    비대화형(파이프 입력 등) 환경에서는 자동 승인하여 워크플로가 멈추지 않게 한다.
+    """
+    strategy = payload.get("strategy", "?")
+    queries = payload.get("search_queries", [])
+    print("\n[확인 요청] 재작성 전략이 사용자 확인을 요구합니다.")
+    print(f"  전략: {strategy}")
+    print(f"  원질의: {payload.get('original_query', '')}")
+    for i, q in enumerate(queries, 1):
+        print(f"  검색쿼리 {i}: {q}")
+
+    if not sys.stdin.isatty():
+        print("  (비대화형 환경 → 자동 승인)")
+        return {"action": "approve"}
+
+    choice = input("  진행할까요? [Enter=승인 / r=재작성 요청]: ").strip().lower()
+    if choice == "r":
+        feedback = input("  재작성 피드백을 입력하세요: ").strip()
+        return {"action": "rewrite", "feedback": feedback}
+    return {"action": "approve"}
+
+
+def _extract_interrupt_payload(result: dict) -> dict:
+    """invoke 결과의 __interrupt__ 값을 dict 페이로드로 정규화한다."""
+    intr = result["__interrupt__"]
+    item = intr[0] if isinstance(intr, (list, tuple)) and intr else intr
+    payload = getattr(item, "value", item)
+    return payload if isinstance(payload, dict) else {}
+
+
+def _print_response(result: dict) -> None:
+    """워크플로 결과의 FinalResponse를 사람이 읽기 좋게 출력한다."""
+    response = result.get("final_response")
+    print("\n" + "=" * 60)
+    if response is None:
+        print("답변을 생성하지 못했습니다.")
+        return
+
+    print(f"답변:\n{response.answer}\n")
+    print(f"답변 가능 여부: {response.is_answerable}")
+    print(f"신뢰도: {response.confidence_score:.2%}")
+
+    if response.citations:
+        print(f"\n인용 ({len(response.citations)}건):")
+        for c in response.citations:
+            snippet = c.content.replace("\n", " ")[:80]
+            print(f"  - [{c.document_id} / {c.chunk_id}] (rel={c.relevance_score:.2f}) {snippet}...")
+    else:
+        print("\n인용: 없음")
+    print("=" * 60)
+
+
+def run_query(args) -> int:
+    """질의 경로 실행. HIL interrupt가 발생하면 결정을 받아 재개한다."""
+    from src.agent.workflow import resume_workflow, run_workflow
+
+    init_pool()
+    try:
+        logger.info(f"질의 실행: '{args.query}' (standard={args.standard})")
+        result = run_workflow(args.query, standard_filter=args.standard)
+
+        # human_review interrupt 루프: __interrupt__가 사라질 때까지 결정을 주입해 재개
+        while "__interrupt__" in result:
+            decision = _prompt_human_decision(_extract_interrupt_payload(result))
+            result = resume_workflow(result["thread_id"], decision)
+
+        _print_response(result)
+        return 0
+    finally:
+        close_pool()
+
+
+# ───────────────────────────── CLI 구성 ─────────────────────────────
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        prog="rag-for-accounting",
+        description="회계 기준서 RAG — 적재(ingest)/질의(query) 진입점",
+    )
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    # ingest
+    p_ingest = sub.add_parser("ingest", help="문서를 청킹·임베딩하여 pgvector에 적재")
+    p_ingest.add_argument(
+        "--ontology-dir",
+        default="data/ontology",
+        help="적재할 온톨로지 JSON 디렉토리 (기본: data/ontology). --pdf/--md 미지정 시 사용",
+    )
+    p_ingest.add_argument("--pdf", help="단일 PDF에서 파싱→온톨로지→적재까지 전체 경로 실행")
+    p_ingest.add_argument("--md", help="단일 마크다운에서 온톨로지→적재 실행")
+    p_ingest.add_argument("--standard-id", help="--pdf/--md 사용 시 기준서 ID (예: gaap-ch6)")
+    p_ingest.add_argument(
+        "--standard-type",
+        choices=["GAAP", "KIFRS"],
+        help="--pdf/--md 사용 시 기준 유형",
+    )
+    p_ingest.add_argument(
+        "--collection",
+        default=CHUNKS_TABLE,
+        help=f"적재 대상 테이블 (기본: {CHUNKS_TABLE} — 검색기와 동일 테이블)",
+    )
+    p_ingest.add_argument("--reset", action="store_true", help="적재 전 컬렉션을 비운다")
+    p_ingest.set_defaults(func=run_ingest)
+
+    # query
+    p_query = sub.add_parser("query", help="질의에 대해 워크플로를 실행하고 답변을 출력")
+    p_query.add_argument("query", help="질의 문장")
+    p_query.add_argument(
+        "--standard",
+        choices=["GAAP", "KIFRS", "ALL"],
+        default="ALL",
+        help="검색 대상 기준 필터 (기본: ALL)",
+    )
+    p_query.set_defaults(func=run_query)
+
+    return parser
+
+
+def main(argv: list[str] | None = None) -> int:
+    load_dotenv()
+    parser = build_parser()
+    args = parser.parse_args(argv)
+
+    # --pdf/--md 사용 시 standard-id/type은 필수
+    if args.command == "ingest" and (args.pdf or args.md):
+        if not args.standard_id or not args.standard_type:
+            parser.error("--pdf/--md 사용 시 --standard-id 와 --standard-type 이 필요합니다.")
+
+    return args.func(args)
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## 개요

README에 명시되어 있으나 미구현 상태였던 `main.py` 실행 진입점을 구현합니다. v1.0(B안) 목표인 **실데이터 E2E 관통**을 위해 적재(ingest)·질의(query) 두 실행 경로를 단일 CLI로 제공합니다.

Closes #95

---

## 변경 사항

### 신규 구현

- **`src/main.py`** — `ingest`/`query` 두 서브커맨드를 제공하는 실행 진입점
  - **ingest**: 온톨로지 그래프 → 청킹(`chunk_graph`) → pgvector 적재(`index_documents`). 기본은 `data/ontology/*.json` 재사용, `--pdf`/`--md`로 파싱(FUNC-001)→온톨로지 빌드(FUNC-002) 전체 경로도 지원, `--reset` 옵션 제공
  - **query**: `run_workflow` 실행 + HIL(human_review) interrupt 대화형 루프 처리 + 답변/인용/신뢰도 출력

### 수정

- **`README.md`** — "현재 구현되어 있지 않습니다" 제거, ingest/query 실행 가이드 및 DB 기동 안내 추가

---

## 아키텍처

### 처리 흐름

```text
[ingest]  data/ontology/*.json (또는 --pdf/--md)
            │  (--pdf: DoclingParser 파싱 → build_graph 온톨로지)
            ▼
        chunk_graph (온톨로지 노드 → RetrievedChunk, 토큰 한도 분할)
            ▼
        index_documents (KURE-v1 임베딩 → pgvector upsert)
            ▼
        테이블 'chunks'

[query]   질의 → run_workflow
            rewrite → (human_review) → search → rerank → evaluate → generate
            │  (interrupt 발생 시 대화형 승인/재작성 → resume_workflow)
            ▼
        FinalResponse (답변 + 인용 + 신뢰도) 출력
```

### 주요 설계 결정

**적재 테이블을 `CHUNKS_TABLE("chunks")`로 고정**
검색기(`searcher.py`)는 `CHUNKS_TABLE="chunks"`를 조회하지만 `index_documents`의 `collection` 인자에는 기본값이 없습니다. 적재와 검색이 어긋나지 않도록 ingest의 기본 컬렉션을 `CHUNKS_TABLE`로 고정해 동일 테이블을 공유하게 했습니다.

**무거운 모듈은 함수 내부에서 지연 임포트**
임베딩 모델·워크플로 등 무거운 의존성을 서브커맨드 핸들러 내부에서 임포트하여, `ingest` 실행 시 워크플로를, `query` 실행 시 적재 의존성을 불필요하게 로드하지 않도록 했습니다. (`--help` 응답성도 확보)

**비대화형 환경에서의 HIL 자동 승인**
`query`의 human_review interrupt는 TTY에서는 승인/재작성을 입력받고, 파이프 입력 등 비대화형 환경에서는 자동 승인하여 워크플로가 멈추지 않게 합니다.

**멱등 재적재**
청킹의 결정적 `chunk_id`와 `index_documents`의 `ON CONFLICT` upsert 덕분에 ingest 재실행이 멱등합니다. (대량 적재 중단 시 누락분만 안전하게 재적재 가능)

---

## E2E 관통 검증

- **적재**: 전체 **33장 / 1,042청크**를 `chunks` 테이블에 적재 완료 (누락 장 0)
- **질의**: 실데이터 기반 답변 검증
  - 유형자산(ch10): 취득원가 구성 — 신뢰도 99.40%, 인용 `gaap-ch10-유형자산의_취득원가`
  - 리스 분류(ch13): 금융리스 분류 기준 — 신뢰도 98.80%, 인용 `gaap-ch13-리스의_분류` 외 1건

---

## 후속 / 관련

- 대량 적재 시 임베딩(KURE-v1, CPU) CPU 포화·메모리 누적 OOM 및 실행 위치(아키텍처) 문제는 별도 이슈 #117로 분리
- 근거: 2026-06-07 회의 결정 D1(B안), 기한 7/4 릴리즈 이전

---

## 체크리스트

- [x] `ingest` 단일 명령으로 전체 33장 적재 확인
- [x] `query` 실데이터 기반 답변·인용 생성 확인 (2개 장 교차 검증)
- [x] 적재·검색 동일 테이블(`chunks`) 정합 확인
- [x] README 실행 가이드 갱신
