### PR TITLE
test: Phase 1 통합 테스트 회귀 해소 — rewrite LLM 모킹 및 chunks 스키마 정합

### DIFF
--- a/tests/integration/inference/conftest.py
+++ b/tests/integration/inference/conftest.py
@@ -1,7 +1,46 @@
+import json
 import pytest
 from unittest.mock import patch, MagicMock
 from src.models.schemas import LLMInternalResponse
 from src.agent.workflow import build_workflow
+
+
+@pytest.fixture(autouse=True)
+def mock_rewrite_llm(request):
+    """
+    system 마커 테스트에서 rewrite 노드(classify_and_select 등)의 LLM 호출을 차단한다.
+
+    Phase 1 시스템 테스트는 "가짜 데이터 기반, 외부 의존성 없음"이 계약이다(pyproject markers).
+    그러나 rewrite 노드는 실제 OpenAI(src.agent.nodes.rewrite.client)를 호출해 회계/비회계를 분류하므로
+    search/rerank/evaluate를 모킹한 시나리오 테스트라도 "에러 복구 테스트" 같은 placeholder 질의가 비회계로 분류되어 route_after_rewrite가 early_exit로 이탈한다.
+    그 결과 검색·평가 파이프라인이 통째로 스킵되고 error_logs/rewrite_count 검증이 깨진다
+
+    여기서 client를 모킹해 항상 (is_accounting=True, strategy="hyde")로 분류시켜
+    파이프라인이 정상적으로 진행되도록 보장한다. 모든 전략 함수가 동일 응답을 안전하게 파싱할 수
+    있도록 hypothetical_answer/sub_queries/abstract_query를 함께 포함한다.
+
+    단, 실제 LLM 분류를 검증하는 test_rewrite_all_queries(system 미표시)에는 적용하지 않는다.
+    """
+    if request.node.get_closest_marker("system") is None:
+        yield
+        return
+
+    content = json.dumps({
+        "is_accounting": True,
+        "strategy": "hyde",
+        "confidence": 0.95,
+        "hypothetical_answer": "테스트용 가상 답변",
+        "sub_queries": ["테스트용 서브쿼리"],
+        "abstract_query": "테스트용 추상 질의",
+    })
+    mock_resp = MagicMock()
+    mock_resp.choices[0].message.content = content
+
+    mock_client = MagicMock()
+    mock_client.chat.completions.create.return_value = mock_resp
+
+    with patch("src.agent.nodes.rewrite.client", mock_client):
+        yield
 
 @pytest.fixture(autouse=True)
 def mock_llm_agent():

--- a/tests/integration/inference/test_hybrid_search_integration.py
+++ b/tests/integration/inference/test_hybrid_search_integration.py
@@ -29,9 +29,12 @@ def setup_test_db():
     with pool.connection() as conn:
         with conn.cursor() as cur:
             # 테스트용 테이블 스키마 생성
+            # 프로덕션 스키마(src/db/vector_store.py)와 동일하게 chunk_id를 TEXT PRIMARY KEY로 둔다.
+            # CREATE TABLE IF NOT EXISTS는 인덱싱 경로가 이미 생성한 chunks 테이블 앞에서 no-op이 되므로,
+            # 테스트 INSERT도 프로덕션 스키마(chunk_id NOT NULL, 자동 증가 없음)에 맞춰 chunk_id를 명시한다.
             cur.execute(f"""
                 CREATE TABLE IF NOT EXISTS {CHUNKS_TABLE} (
-                    chunk_id SERIAL PRIMARY KEY,
+                    chunk_id TEXT PRIMARY KEY,
                     document_id TEXT,
                     content TEXT,
                     metadata JSONB,
@@ -43,14 +46,21 @@ def setup_test_db():
             # (실제 임베딩 벡터와 동일한 차원의 dummy vector 사용)
             dummy_vec_1 = f"[{','.join(['0.1']*EMBEDDING_DIM)}]"
             dummy_vec_2 = f"[{','.join(['0.2']*EMBEDDING_DIM)}]"
-            
+
+            # 재실행 멱등성: 기존 테스트 행이 남아 있어도 ON CONFLICT로 갱신한다.
+            # ON CONFLICT: 중복된 chunk_id가 있을 경우 업데이트하라는 의미이다.
             cur.execute(f"""
-                INSERT INTO {CHUNKS_TABLE} (document_id, content, metadata, embedding)
-                VALUES 
-                ('DOC-1', '유형자산 감가상각 인식 기준은 정액법을 기본으로 합니다.', '{{"standard_type": "K-GAAP"}}', %s::vector),
-                ('DOC-2', '재고자산의 단가산정방식은 선입선출법을 따른다.', '{{"standard_type": "K-IFRS"}}', %s::vector)
+                INSERT INTO {CHUNKS_TABLE} (chunk_id, document_id, content, metadata, embedding)
+                VALUES
+                ('TEST-CHUNK-1', 'DOC-1', '유형자산 감가상각 인식 기준은 정액법을 기본으로 합니다.', '{{"standard_type": "K-GAAP"}}', %s::vector),
+                ('TEST-CHUNK-2', 'DOC-2', '재고자산의 단가산정방식은 선입선출법을 따른다.', '{{"standard_type": "K-IFRS"}}', %s::vector)
+                ON CONFLICT (chunk_id) DO UPDATE SET
+                    document_id = EXCLUDED.document_id,
+                    content = EXCLUDED.content,
+                    metadata = EXCLUDED.metadata,
+                    embedding = EXCLUDED.embedding
             """, [dummy_vec_1, dummy_vec_2])
-            
+
             conn.commit()
             
     yield


### PR DESCRIPTION
## 개요

`uv run pytest -m system`(Phase 1 통합 테스트) 실행 시 발생한 **4 failed + 1 error 회귀**를 해소합니다. 두 회귀 모두 최근 머지된 기능 PR로 인해 드러난 것으로, 프로덕션 코드 변경 없이 테스트 픽스처/모킹 정합만으로 해결합니다.

Closes #120

---

## 변경 사항

### 수정

- **`tests/integration/inference/conftest.py`** — `system` 마커 전용 autouse 픽스처 `mock_rewrite_llm` 추가. rewrite 노드의 `client`를 모킹해 항상 `(is_accounting=True, strategy="hyde")`로 분류시킨다.
- **`tests/integration/inference/test_hybrid_search_integration.py`** — setup 픽스처를 프로덕션 스키마(`chunk_id TEXT PRIMARY KEY`)에 정합하고, INSERT에 명시적 `chunk_id` + `ON CONFLICT DO UPDATE`(재실행 멱등성)를 적용한다.

---

## 원인 분석

### 원인 1 — rewrite 분류 LLM 미모킹으로 비회계 `early_exit` 이탈 (실패 4건)

`#78`(비회계 질의 → `early_exit` 라우팅) 머지 이후 발생한 회귀입니다.

rewrite 노드의 `classify_and_select`(`src/agent/nodes/rewrite.py`)는 **실제 OpenAI를 호출**해 회계/비회계를 분류합니다. 그러나 inference 통합 테스트의 autouse 픽스처(`mock_llm_agent`)는 `generate`의 `Agent`만 차단하고 rewrite의 `client`는 모킹하지 않았습니다.

그 결과 시나리오 테스트의 placeholder 질의(`"에러 복구 테스트"` 등)가 실제 LLM에 의해 **비회계로 분류** → `route_after_rewrite`가 `early_exit`로 분기 → search/rerank/evaluate 파이프라인이 통째로 스킵 → `error_logs`/`rewrite_count` 단언이 깨집니다.

```
AssertionError: error_logs에 evaluate/EV-301가 기록되지 않았습니다.
AssertionError: needs_reretrieval이 evaluate 에러보다 우선되어 rewrite_count=3에 도달해야 합니다. 실제=1
```

`system` 마커는 pyproject에 *"가짜 데이터 기반, 외부 의존성 없음 (Phase 1: Fast Fail)"* 으로 정의되어 있어, 실제 LLM 호출 자체가 마커 계약 위반입니다. 실제 LLM 분류를 검증하는 `test_rewrite_all_queries`(system 미표시)에는 모킹을 적용하지 않습니다.

| 영향 테스트 |
|------|
| `test_node_error_fallback_routing[evaluate_error_fallback]` |
| `test_node_error_fallback_routing[search_error_fallback]` |
| `test_needs_reretrieval_priority_over_evaluate_error` |
| `test_rerank_failure_fallback_preserves_retrieved_chunks` |

### 원인 2 — `chunks` 테이블 스키마 충돌 (`chunk_id` NOT NULL) (에러 1건)

인덱싱/청킹 PR(`#106`, `#111`)로 프로덕션 `chunks` 테이블이 `src/db/vector_store.py`에서 `chunk_id TEXT PRIMARY KEY`로 도입됐습니다.

`test_hybrid_search_integration.py`의 setup 픽스처는 테이블을 `chunk_id SERIAL PRIMARY KEY`로 생성하려 하지만, `CREATE TABLE IF NOT EXISTS`는 이미 존재하는 프로덕션 테이블 앞에서 **no-op**이 됩니다. 이어지는 INSERT가 `chunk_id`를 생략(SERIAL 자동증가 가정)하므로 실제 스키마(`TEXT NOT NULL`, 기본값 없음)에서 NOT NULL 위반이 발생합니다.

```
psycopg.errors.NotNullViolation: null value in column "chunk_id" of relation "chunks" violates not-null constraint
```

---

## 체크리스트

- [x] `uv run pytest -m system` → **29 passed** (기존 28 passed + 1 error 해소)
- [x] 실제 LLM 분류 검증 테스트(`test_rewrite_all_queries`, system 미표시)는 모킹 미적용 — 영향 없음 확인
- [x] 프로덕션 코드 변경 없음 (테스트 픽스처/모킹 정합만 수정)
- [x] system 스위트 실행 시간 단축 (해당 시나리오 약 40s → 0.8s, 실제 LLM 호출 제거)
