### PR TITLE
test: ontology 테스트에 마커 부착해 run_tests.py deselection 해소

### DIFF
--- a/tests/integration/test_ontology_builder.py
+++ b/tests/integration/test_ontology_builder.py
@@ -1,4 +1,5 @@
 """LLM 호출을 모킹하여 파이프라인 구조를 검증한다."""
+import pytest
 from unittest.mock import patch
 from src.db.ontology.builder import build_graph
 from src.db.ontology.edge_extractor import EdgeCandidate
@@ -15,6 +16,7 @@ def _mock_extract(subsection_id, title, content, candidates):
     return []
 
 
+@pytest.mark.system
 def test_graph_has_all_node_types():
     with patch("src.db.ontology.builder.extract_edges", side_effect=_mock_extract):
         graph = build_graph(MD_PATH, "gaap-ch6", "GAAP")
@@ -24,12 +26,14 @@ def test_graph_has_all_node_types():
     assert "Subsection" in types
 
 
+@pytest.mark.system
 def test_graph_has_contains_edges():
     with patch("src.db.ontology.builder.extract_edges", side_effect=_mock_extract):
         graph = build_graph(MD_PATH, "gaap-ch6", "GAAP")
     assert any(e.edge_type == "CONTAINS" for e in graph.edges)
 
 
+@pytest.mark.system
 def test_save_reload(tmp_path):
     from src.db.ontology.builder import save_graph
     from src.db.ontology.models import OntologyGraph

--- a/tests/unit/ontology/test_chunker.py
+++ b/tests/unit/ontology/test_chunker.py
@@ -75,12 +75,14 @@ def _sample_graph() -> OntologyGraph:
     return graph
 
 
+@pytest.mark.unit
 def test_returns_retrieved_chunks():
     """결과물이 RetrievedChunk 타입인지 확인"""
     chunks = chunk_graph(_sample_graph(), token_counter=_word_count)
     assert all(isinstance(c, RetrievedChunk) for c in chunks)
 
 
+@pytest.mark.unit
 def test_only_content_nodes_become_chunks():
     """content 있는 노드만 청크가 되는지 확인"""
     # content 있는 노드: Section 1 + Subsection 2 = 3개. Standard·빈 Section은 제외.
@@ -90,6 +92,7 @@ def test_only_content_nodes_become_chunks():
     assert node_ids == {"gaap-ch6-s1", "gaap-ch6-s1-최초인식", "gaap-ch6-s2-측정"}
 
 
+@pytest.mark.unit
 def test_no_orphan_chunks():
     """모든 청크가 ontology_node_id를 보유하는지 확인 (고아 0건)"""
     chunks = chunk_graph(_sample_graph(), token_counter=_word_count)
@@ -97,12 +100,14 @@ def test_no_orphan_chunks():
     assert all(c.metadata.ontology_node_id for c in chunks)
 
 
+@pytest.mark.unit
 def test_score_is_zero():
     """모든 청크의 score가 0.0인지 확인"""
     chunks = chunk_graph(_sample_graph(), token_counter=_word_count)
     assert all(c.score == 0.0 for c in chunks)
 
 
+@pytest.mark.unit
 def test_unsplit_chunk_id_equals_node_id():
     """분할되지 않은 노드는 chunk_id == node.id (노드 ↔ 청크 1:1)인지 확인"""
     chunks = chunk_graph(_sample_graph(), token_counter=_word_count)
@@ -110,18 +115,21 @@ def test_unsplit_chunk_id_equals_node_id():
         assert c.chunk_id == c.metadata.ontology_node_id
 
 
+@pytest.mark.unit
 def test_document_id_defaults_to_standard_id():
     """document_id가 없으면 Standard 노드의 id를 사용"""
     chunks = chunk_graph(_sample_graph(), token_counter=_word_count)
     assert all(c.document_id == "gaap-ch6" for c in chunks)
 
 
+@pytest.mark.unit
 def test_document_id_override():
     """document_id를 지정하면 해당 id를 사용"""
     chunks = chunk_graph(_sample_graph(), document_id="custom-doc", token_counter=_word_count)
     assert all(c.document_id == "custom-doc" for c in chunks)
 
 
+@pytest.mark.unit
 def test_metadata_propagation():
     """metadata 전파 테스트 - standard_type·chapter·source_path"""
     chunks = chunk_graph(
@@ -137,17 +145,20 @@ def test_metadata_propagation():
     assert sample.metadata.model_extra.get("source_path") == "data/회계_sample.pdf"
 
 
+@pytest.mark.unit
 def test_source_path_omitted_when_not_given():
     """source_path가 주어지지 않으면 extra에 포함되지 않음"""
     chunks = chunk_graph(_sample_graph(), token_counter=_word_count)
     assert "source_path" not in (chunks[0].metadata.model_extra or {})
 
 
+@pytest.mark.unit
 def test_empty_graph_returns_empty_list():
     """빈 그래프는 빈 리스트를 반환"""
     assert chunk_graph(OntologyGraph(), token_counter=_word_count) == []
 
 
+@pytest.mark.unit
 def test_graph_without_content_nodes_returns_empty_list():
     """content 노드가 없는 그래프는 빈 리스트를 반환"""
     # Standard 노드만 있고 content 노드가 없는 경우 → 빈 리스트 (에러 아님).
@@ -158,6 +169,7 @@ def test_graph_without_content_nodes_returns_empty_list():
     assert chunk_graph(graph, token_counter=_word_count) == []
 
 
+@pytest.mark.unit
 def test_missing_standard_raises_when_document_id_absent():
     """content 노드는 있는데 Standard도 없고 document_id도 안 주면 식별자를 못 정한다."""
     graph = OntologyGraph()
@@ -168,6 +180,7 @@ def test_missing_standard_raises_when_document_id_absent():
         chunk_graph(graph, token_counter=_word_count)
 
 
+@pytest.mark.unit
 def test_missing_standard_ok_when_document_id_given():
     """Standard가 없어도 document_id가 있으면 chunk_graph가 정상 동작"""
     graph = OntologyGraph()
@@ -182,6 +195,7 @@ def test_missing_standard_ok_when_document_id_given():
     assert chunks[0].metadata.chapter is None
 
 
+@pytest.mark.unit
 def test_oversized_node_is_split_by_paragraph():
     """노드가 토큰 한도를 초과하면 문단 단위로 분할되는지 확인"""
     # max_tokens=5(단어 5개) 한도. 4문단 × 단어 4개씩 = 분할 발생.
@@ -215,6 +229,7 @@ def test_oversized_node_is_split_by_paragraph():
     assert all(_word_count(c.content) <= 5 for c in chunks)
 
 
+@pytest.mark.unit
 def test_split_preserves_no_data_loss():
     """분할 후에도 전체 단어가 보존되어야 한다 (손실 없음)"""
     graph = OntologyGraph()
@@ -230,6 +245,7 @@ def test_split_preserves_no_data_loss():
     assert recombined == words
 
 
+@pytest.mark.unit
 def test_hard_split_when_single_unit_exceeds_limit():
     """줄·문장으로 못 나누는 한 덩어리(공백 없는 긴 문자열)는 문자 단위로 강제 분할"""
     graph = OntologyGraph()
@@ -248,6 +264,7 @@ def test_hard_split_when_single_unit_exceeds_limit():
     assert "".join(c.content for c in chunks) == long_text
 
 
+@pytest.mark.unit
 def test_chunk_id_determinism():
     """동일 입력 재실행 → 동일 chunk_id (upsert 멱등성의 전제) 확인"""
     first = chunk_graph(_sample_graph(), token_counter=_word_count)

--- a/tests/unit/ontology/test_edge_detector.py
+++ b/tests/unit/ontology/test_edge_detector.py
@@ -1,41 +1,50 @@
+import pytest
 from src.db.ontology.edge_detector import detect_candidates
 
 
+@pytest.mark.unit
 def test_detects_다만():
     content = "- ⑵ 리스에 따른 권리와 의무 . 다만 , ㈎ 리스채권에 대하여는 이 장을 적용한다 ."
     assert any("다만" in c for c in detect_candidates(content))
 
 
+@pytest.mark.unit
 def test_detects_제외():
     content = "- 6.5 금융자산 ( 제 2 절 유가증권의 적용대상 금융자산은 제외 ) 의 양도의 경우에"
     assert any("제외" in c for c in detect_candidates(content))
 
 
+@pytest.mark.unit
 def test_detects_section_ref():
     content = "- 6.3 제 2 절 ~ 제 4 절 에서 정하지 않은 사항은 이 절에서 제시하는 원칙을 적용한다 ."
     assert len(detect_candidates(content)) >= 1
 
 
+@pytest.mark.unit
 def test_detects_문단_ref():
     content = "- 6.21 유가증권의 최초 인식에 관한 규정은 이 장의 제 1 절 공통사항 문단 6.4 를 따른다 ."
     assert any("문단" in c for c in detect_candidates(content))
 
 
+@pytest.mark.unit
 def test_detects_문단_실_prefix():
     content = "- 6.76 파생상품의 정의에 대하여는 문단 실6.54의 2 를 참조한다 ."
     assert any("문단" in c for c in detect_candidates(content))
 
 
+@pytest.mark.unit
 def test_detects_문단_range():
     content = "- 6.14 후속 측정에 대하여는 문단 6.5~6.7 을 적용한다 ."
     assert any("문단" in c for c in detect_candidates(content))
 
 
+@pytest.mark.unit
 def test_detects_불구하고():
     content = "- 6.89 위의 규정에 불구하고 다음의 경우에는 별도의 처리를 한다 ."
     assert any("불구하고" in c for c in detect_candidates(content))
 
 
+@pytest.mark.unit
 def test_no_false_positive():
     content = "- 6.7 매각거래와 관련하여 취득하거나 부담하는 자산 및 부채의 예로는 위탁수수료를 들 수 있다 ."
     assert detect_candidates(content) == []

--- a/tests/unit/ontology/test_edge_extractor.py
+++ b/tests/unit/ontology/test_edge_extractor.py
@@ -1,3 +1,4 @@
+import pytest
 import json
 from unittest.mock import MagicMock, patch
 from src.db.ontology.edge_extractor import extract_edges, EdgeCandidate
@@ -13,6 +14,7 @@ def _mock_response(edges: list[dict]):
     return mock_resp
 
 
+@pytest.mark.unit
 def test_empty_candidates_returns_without_llm_call():
     with patch("src.db.ontology.edge_extractor.client") as mc:
         result = extract_edges("gaap-ch6-s1-공통", "공통사항", "내용", [])
@@ -20,6 +22,7 @@ def test_empty_candidates_returns_without_llm_call():
         mc.chat.completions.create.assert_not_called()
 
 
+@pytest.mark.unit
 def test_returns_list():
     with patch("src.db.ontology.edge_extractor.client") as mc:
         mc.chat.completions.create.return_value = _mock_response([])
@@ -27,6 +30,7 @@ def test_returns_list():
         assert isinstance(result, list)
 
 
+@pytest.mark.unit
 def test_references_edge():
     data = {"edge_type": "REFERENCES", "paragraph": "6.3", "target_ref": "제2절",
             "source_text": "제2절에서 정하지 않은 사항은 이 절에서 적용한다.", "include": [], "condition_text": ""}
@@ -37,6 +41,7 @@ def test_references_edge():
         assert result[0].target_ref == "제2절"
 
 
+@pytest.mark.unit
 def test_excludes_with_include():
     data = {"edge_type": "EXCLUDES", "paragraph": "6.2⑵", "target_ref": "리스 관련",
             "source_text": "리스. 다만, 리스채권은 적용한다.", "include": ["리스채권의 제거와 손상"], "condition_text": ""}
@@ -46,6 +51,7 @@ def test_excludes_with_include():
         assert "리스채권의 제거와 손상" in result[0].include
 
 
+@pytest.mark.unit
 def test_is_default_for_edge():
     data = {"edge_type": "IS_DEFAULT_FOR", "paragraph": "6.3", "target_ref": "제2절",
             "source_text": "제2절~제4절에서 정하지 않은 사항은 이 절에서 적용한다.", "include": [], "condition_text": ""}
@@ -56,6 +62,7 @@ def test_is_default_for_edge():
         assert result[0].target_ref == "제2절"
 
 
+@pytest.mark.unit
 def test_none_filtered():
     data = {"edge_type": "NONE", "paragraph": "", "target_ref": "",
             "source_text": "단순 서술", "include": [], "condition_text": ""}

--- a/tests/unit/ontology/test_md_parser.py
+++ b/tests/unit/ontology/test_md_parser.py
@@ -1,3 +1,4 @@
+import pytest
 from src.db.ontology.md_parser import parse_markdown
 from src.db.ontology.models import OntologyGraph
 
@@ -22,11 +23,13 @@ SAMPLE_MD = """# 제 6 장 금융자산 · 금융부채
 """
 
 
+@pytest.mark.unit
 def test_parse_returns_graph():
     graph = parse_markdown(SAMPLE_MD, standard_id="gaap-ch6", standard_type="GAAP")
     assert isinstance(graph, OntologyGraph)
 
 
+@pytest.mark.unit
 def test_standard_node_created():
     graph = parse_markdown(SAMPLE_MD, standard_id="gaap-ch6", standard_type="GAAP")
     standards = [n for n in graph.nodes if n.node_type == "Standard"]
@@ -35,12 +38,14 @@ def test_standard_node_created():
     assert "금융자산" in standards[0].name
 
 
+@pytest.mark.unit
 def test_standard_chapter_extracted_from_markdown():
     graph = parse_markdown(SAMPLE_MD, standard_id="gaap-ch6", standard_type="GAAP")
     standard = next(n for n in graph.nodes if n.node_type == "Standard")
     assert standard.chapter == "6"
 
 
+@pytest.mark.unit
 def test_section_node_created():
     graph = parse_markdown(SAMPLE_MD, standard_id="gaap-ch6", standard_type="GAAP")
     sections = [n for n in graph.nodes if n.node_type == "Section"]
@@ -48,6 +53,7 @@ def test_section_node_created():
     assert "공통사항" in sections[0].title
 
 
+@pytest.mark.unit
 def test_subsection_nodes_created():
     graph = parse_markdown(SAMPLE_MD, standard_id="gaap-ch6", standard_type="GAAP")
     subsections = [n for n in graph.nodes if n.node_type == "Subsection"]
@@ -56,18 +62,21 @@ def test_subsection_nodes_created():
     assert "금융상품의 최초인식" in titles
 
 
+@pytest.mark.unit
 def test_subsection_paragraphs():
     graph = parse_markdown(SAMPLE_MD, standard_id="gaap-ch6", standard_type="GAAP")
     sub = next(n for n in graph.nodes if n.node_type == "Subsection" and n.title == "적용범위")
     assert "6.2" in sub.paragraphs
 
 
+@pytest.mark.unit
 def test_subsection_content_not_empty():
     graph = parse_markdown(SAMPLE_MD, standard_id="gaap-ch6", standard_type="GAAP")
     sub = next(n for n in graph.nodes if n.node_type == "Subsection" and n.title == "금융상품의 최초인식")
     assert "6.4" in sub.content
 
 
+@pytest.mark.unit
 def test_contains_edges_exist():
     graph = parse_markdown(SAMPLE_MD, standard_id="gaap-ch6", standard_type="GAAP")
     contains = [e for e in graph.edges if e.edge_type == "CONTAINS"]

--- a/tests/unit/ontology/test_models.py
+++ b/tests/unit/ontology/test_models.py
@@ -1,6 +1,8 @@
+import pytest
 from src.db.ontology.models import OntologyNode, OntologyEdge, OntologyGraph
 
 
+@pytest.mark.unit
 def test_standard_node():
     node = OntologyNode(
         id="gaap-ch6",
@@ -13,6 +15,7 @@ def test_standard_node():
     assert node.chapter == "6"
 
 
+@pytest.mark.unit
 def test_subsection_node_defaults():
     node = OntologyNode(
         id="gaap-ch6-s1-최초인식",
@@ -23,6 +26,7 @@ def test_subsection_node_defaults():
     assert node.paragraphs == []
 
 
+@pytest.mark.unit
 def test_references_edge():
     edge = OntologyEdge(
         from_id="gaap-ch6-s1-후속측정",
@@ -35,6 +39,7 @@ def test_references_edge():
     assert edge.include == []
 
 
+@pytest.mark.unit
 def test_excludes_edge_with_include():
     edge = OntologyEdge(
         from_id="gaap-ch6-적용범위",
@@ -46,6 +51,7 @@ def test_excludes_edge_with_include():
     assert len(edge.include) == 2
 
 
+@pytest.mark.unit
 def test_unresolved_edge():
     edge = OntologyEdge(
         from_id="gaap-ch6-s1-최초인식",
@@ -57,6 +63,7 @@ def test_unresolved_edge():
     assert edge.unresolved_target == "제8장 문단 8.2"
 
 
+@pytest.mark.unit
 def test_is_default_for_edge():
     edge = OntologyEdge(
         from_id="gaap-ch6-s1-공통원칙",
@@ -67,6 +74,7 @@ def test_is_default_for_edge():
     assert edge.edge_type == "IS_DEFAULT_FOR"
 
 
+@pytest.mark.unit
 def test_ontology_graph_defaults():
     graph = OntologyGraph()
     assert graph.nodes == []

--- a/tests/unit/ontology/test_resolver.py
+++ b/tests/unit/ontology/test_resolver.py
@@ -1,3 +1,4 @@
+import pytest
 from src.db.ontology.models import OntologyGraph, OntologyNode, OntologyEdge
 from src.db.ontology.resolver import build_lookup, resolve_edges, _expand_range_target
 
@@ -12,22 +13,26 @@ def _make_graph() -> OntologyGraph:
     ])
 
 
+@pytest.mark.unit
 def test_lookup_chapter():
     lookup = build_lookup(_make_graph())
     assert lookup.get("제6장") == "gaap-ch6"
 
 
+@pytest.mark.unit
 def test_lookup_section():
     lookup = build_lookup(_make_graph())
     assert lookup.get("제2절") == "gaap-ch6-s2"
 
 
+@pytest.mark.unit
 def test_lookup_paragraph():
     lookup = build_lookup(_make_graph())
     assert lookup.get("6.4") == "gaap-ch6-s1-최초인식"
     assert lookup.get("문단6.4") == "gaap-ch6-s1-최초인식"
 
 
+@pytest.mark.unit
 def test_resolve_success():
     graph = _make_graph()
     graph.edges = [OntologyEdge(
@@ -39,6 +44,7 @@ def test_resolve_success():
     assert resolved.edges[0].unresolved_target == ""
 
 
+@pytest.mark.unit
 def test_resolve_section_does_not_set_to_paragraph():
     """절로 해소된 엣지는 norm에 문단 패턴이 섞여 있어도 to_paragraph를 비워둔다.
 
@@ -55,6 +61,7 @@ def test_resolve_section_does_not_set_to_paragraph():
     assert resolved.edges[0].to_paragraph == ""
 
 
+@pytest.mark.unit
 def test_resolve_subsection_sets_to_paragraph():
     """Subsection으로 해소된 엣지는 to_paragraph를 정상적으로 채운다."""
     graph = _make_graph()
@@ -67,6 +74,7 @@ def test_resolve_subsection_sets_to_paragraph():
     assert resolved.edges[0].to_paragraph == "6.4"
 
 
+@pytest.mark.unit
 def test_resolve_failure_records_unresolved():
     graph = _make_graph()
     graph.edges = [OntologyEdge(
@@ -82,18 +90,21 @@ def test_resolve_failure_records_unresolved():
 # start/end의 prefix(실·결·사례)가 다르면 확장하지 않고 None을 반환해
 # 존재하지 않는 문단 번호(예: "실6.67")가 만들어지는 것을 막는다.
 
+@pytest.mark.unit
 def test_expand_range_same_prefix_expands_inclusive():
     # 같은 종류(본문)의 연속 범위는 끝 번호까지 포함해 확장한다.
     paras = ["6.8의2", "6.9", "6.10", "6.11"]
     assert _expand_range_target("문단 6.8의2~6.11", paras) == paras
 
 
+@pytest.mark.unit
 def test_expand_range_practice_prefix_expands():
     # 실무지침(실) prefix가 양쪽 모두 일치하면 정상 확장한다.
     paras = ["실6.66", "실6.67"]
     assert _expand_range_target("문단 실6.66~실6.67", paras) == paras
 
 
+@pytest.mark.unit
 def test_expand_range_prefix_mismatch_returns_none():
     # 시작은 "실6.66", 끝은 prefix 없는 "6.67"인 경우.
     # start prefix를 그대로 끌어다 "실6.67"을 만들면 안 되므로 None을 반환한다.
@@ -101,6 +112,7 @@ def test_expand_range_prefix_mismatch_returns_none():
     assert _expand_range_target("문단 실6.66~6.67", paras) is None
 
 
+@pytest.mark.unit
 def test_resolve_range_prefix_mismatch_keeps_unresolved():
     # _expand_range_target가 None이면 resolver는 원문을 그대로 남겨 수동 확인이 가능하게 하고
     # 잘못된 부분의 매핑 엣지를 만들지 않는다.
@@ -120,6 +132,7 @@ def test_resolve_range_prefix_mismatch_keeps_unresolved():
     assert resolved.edges[0].unresolved_target == "문단 실6.66~6.67"
 
 
+@pytest.mark.unit
 def test_resolve_range_splits_into_multiple_edges():
     # 동일 prefix 범위는 paragraph마다 개별 REFERENCES 엣지로 분리된다.
     graph = OntologyGraph(nodes=[


### PR DESCRIPTION
## 개요

ontology 테스트 61개가 pytest 마커 미부착으로 `tests/run_tests.py` 실행 시 **영구 deselected**되어 한 번도 실행되지 않던 문제를 해결합니다. (closes #121)

`run_tests.py`는 각 Phase를 마커(`-m unit` / `-m system` / `-m benchmark`)로 고정해 실행하므로, 어떤 마커도 없는 테스트는 모든 Phase의 수집 단계에서 제외됩니다. `skip`(런타임, DB·`.env` 검증)과 달리 `deselected`(수집 단계, 마커 필터)는 인프라 상태와 무관하게 발생합니다.

---

## 변경 사항

### 수정

- **`tests/unit/ontology/*.py`** (6개 파일) — 각 테스트 함수에 `@pytest.mark.unit` 부착 (58개)
  - `test_chunker.py`, `test_edge_detector.py`, `test_edge_extractor.py`, `test_md_parser.py`, `test_models.py`, `test_resolver.py`
  - `import pytest`가 없던 파일에는 import 그룹 상단에 추가
- **`tests/integration/test_ontology_builder.py`** — 각 테스트 함수에 `@pytest.mark.system` 부착 (3개)
  - LLM 호출을 모킹하고 샘플 MD로 파이프라인 구조만 검증하는 "가짜 데이터 기반" 성격이라 `system`(Phase 1: Fast Fail)으로 분류

> 마커 부착은 기존 `tests/unit/parse/test_parser.py` 컨벤션(테스트별 `@pytest.mark.*` 데코레이터)을 따랐습니다.

---

## 실측: deselection 해소

| 구분 | 변경 전 | 변경 후 |
|------|---------|---------|
| `tests/unit/` `-m unit` | 223/281 (58 deselected) | 276 passed, 5 skipped (**0 deselected**) |
| `tests/unit/ontology/` `-m unit` | 0 (전부 deselected) | **58 passed** |
| `tests/integration/test_ontology_builder.py` `-m system` | 0 (전부 deselected) | **3 passed** |

---

## 체크리스트

- [x] ontology unit 테스트 58개 수집·통과
- [x] ontology_builder system 테스트 3개 수집·통과
- [x] 전체 unit Phase deselection 0건 확인
- [x] 기존 마커 부착 컨벤션(`@pytest.mark.*` 데코레이터) 준수
