### PR TITLE
test: 단위 테스트용 HIL 비활성화 경로 도입 (build_workflow checkpointer=None) (#92)

### DIFF
--- a/src/agent/workflow.py
+++ b/src/agent/workflow.py
@@ -2,7 +2,7 @@
 
 import uuid
 from datetime import datetime
-from functools import wraps
+from functools import wraps, partial
 from typing import Any, Literal
 from langchain_core.runnables import RunnableConfig
 from langgraph.errors import GraphRecursionError
@@ -128,7 +128,7 @@ def route_after_rewrite(state: GraphState) -> Literal["early_exit", "human_revie
 HIL_STRATEGIES: set[str] = {"decompose", "stepback"}
 
 
-def human_review(state: GraphState) -> dict:
+def human_review(state: GraphState, *, hil_enabled: bool = True) -> dict:
     """
     조건부 Human-in-the-Loop 노드.
 
@@ -140,11 +140,17 @@ def human_review(state: GraphState) -> dict:
     재개 시 주입되는 값의 action에 따라 분기한다.
       - action="rewrite": human_feedback 저장 + hil_count 증가 → route_after_human_review가 rewrite로 루프백
       - 그 외(approve 등): human_approved=True 설정 → search로 진행
+
+    hil_enabled=False이면 어떤 전략이든 interrupt 없이 통과한다(단위 테스트용 HIL 비활성화 경로)
+    build_workflow가 checkpointer 부재 시 이 값을 False로 바인딩한다. interrupt()는 checkpointer 없이는
+    호출할 수 없으므로, checkpointer가 없는 단발성 그래프에서 decompose/stepback 질의가 런타임 에러를
+    일으키지 않고 search로 통과하도록 보장한다. (프로덕션 기본값은 True로 동작 불변)
     """
     strategy = state.rewritten_query.strategy if state.rewritten_query else "hyde"
 
     should_review = (
-        strategy in HIL_STRATEGIES
+        hil_enabled
+        and strategy in HIL_STRATEGIES
         and not state.human_approved
         and state.hil_count < MAX_HIL_COUNT
     )
@@ -376,6 +382,8 @@ def build_workflow(checkpointer: BaseCheckpointSaver | None = None) -> CompiledS
     Args:
         checkpointer: HIL(interrupt/resume)을 위한 상태 저장소.
         None이면 체크포인트 없이 컴파일되며 interrupt()를 호출할 수 없다(단순 단방향 실행 전용).
+        이때 human_review 노드는 HIL 비활성화(hil_enabled=False)로 바인딩되어 decompose/stepback
+        질의도 interrupt 없이 search로 통과한다.
         HIL을 사용하는 run_workflow/resume_workflow는 MemorySaver 싱글턴(_CHECKPOINTER)을 주입한다.
 
     return CompiledStateGraph : LangGraph로 빌드된 상태 그래프
@@ -385,10 +393,14 @@ def build_workflow(checkpointer: BaseCheckpointSaver | None = None) -> CompiledS
     """
     workflow = StateGraph(GraphState)
 
+    # checkpointer가 없으면 interrupt()를 호출할 수 없으므로 HIL을 비활성화한다.
+    # human_review 노드는 state만 받으므로 partial로 hil_enabled를 바인딩해 주입한다.
+    hil_enabled = checkpointer is not None
+
     # 노드 추가
     workflow.add_node("rewrite", rewrite)
     workflow.add_node("early_exit", early_exit)
-    workflow.add_node("human_review", human_review)
+    workflow.add_node("human_review", partial(human_review, hil_enabled=hil_enabled))
     workflow.add_node("search", search)
     workflow.add_node("rerank", rerank)
     workflow.add_node("evaluate", evaluate)

--- a/tests/unit/agent/test_hil_workflow.py
+++ b/tests/unit/agent/test_hil_workflow.py
@@ -43,6 +43,16 @@ def hil_app():
     return build_workflow(checkpointer=MemorySaver())
 
 
+@pytest.fixture
+def hil_disabled_workflow():
+    """checkpointer 없이 컴파일해 HIL을 비활성화한 단발성 실행 워크플로우 (단위 테스트용, #92).
+
+    checkpointer가 없으면 build_workflow가 human_review를 hil_enabled=False로 바인딩하므로
+    decompose/stepback 질의도 interrupt 없이 search로 통과한다.
+    """
+    return build_workflow(checkpointer=None)
+
+
 def _decompose_state_query():
     """rewrite가 decompose 전략으로 분류되도록 강제하는 patch 컨텍스트 헬퍼용 질의"""
     return "유형자산과 무형자산의 감가상각 방법 차이는?"
@@ -236,3 +246,60 @@ class TestRunResumeWorkflow:
         assert resumed["thread_id"] == "run-int-1" # thread_id 유지 확인
         assert "__interrupt__" not in resumed   # interrupt 발생하지 않음
         assert resumed["final_response"] is not None # 최종 응답 생성 확인
+
+
+# ── HIL 비활성화 경로 (#92): 단위 테스트용 단발성 실행 ──────────────────────────
+
+@pytest.mark.unit
+class TestHumanReviewHILDisabled:
+    """human_review 노드 단위 — hil_enabled=False면 HIL 트리거 전략도 통과한다."""
+
+    @pytest.mark.parametrize("strategy", ["decompose", "stepback"])
+    def test_hil_disabled_passes_through(self, strategy):
+        """hil_enabled=False면 decompose/stepback도 interrupt 없이 빈 dict 반환(통과)"""
+        state = GraphState(
+            original_query="q",
+            rewritten_query=RewrittenQuery(original_query="q", strategy=strategy, search_queries=["q"]),
+        )
+        assert human_review(state, hil_enabled=False) == {}    # 비활성화 시 전략 무관 통과
+
+
+@pytest.mark.unit
+class TestHILDisabledGraph:
+    """checkpointer 없는 그래프(E2E) — HIL 트리거 전략이 interrupt 없이 끝까지 완료된다."""
+
+    def _invoke(self, app, strategy: str, config=None):
+        """주어진 전략으로 분류되도록 강제하여 워크플로우를 invoke.
+
+        checkpointer 없는 그래프는 config 없이, checkpointer 있는 그래프는 thread_id config로 호출한다.
+        """
+        with patch(
+            "src.agent.nodes.rewrite.classify_and_select",
+            return_value=(True, strategy, 0.8),
+        ), patch("src.agent.nodes.rewrite.client") as mock_client:
+            # decompose(sub_queries)·stepback(abstract_query) 양쪽 키를 모두 담아 전략 무관 대응
+            mock_client.chat.completions.create.return_value = _mock_resp({
+                "sub_queries": ["유형자산 감가상각은?", "무형자산 상각은?"],
+                "abstract_query": "감가상각의 일반 원칙은?",
+            })
+            return app.invoke(GraphState(original_query=_decompose_state_query()), config=config)
+
+    @pytest.mark.parametrize("strategy", ["decompose", "stepback"])
+    def test_hil_strategy_completes_without_interrupt(self, hil_disabled_workflow, mock_searcher, strategy):
+        """비활성화 그래프에서는 decompose/stepback도 interrupt 없이 search→generate까지 완료된다"""
+        result = self._invoke(hil_disabled_workflow, strategy)
+
+        assert "__interrupt__" not in result    # interrupt 발생하지 않음 (단발성 완료)
+        mock_searcher.assert_called()                 # HIL을 통과해 search 노드 진입
+        assert result["final_response"] is not None  # 최종 응답 생성 확인
+        assert result["human_approved"] is False     # 승인 절차 없이 통과 (상태 변경 없음)
+
+    @pytest.mark.parametrize("strategy", ["decompose", "stepback"])
+    def test_hil_enabled_graph_interrupts_same_input(self, hil_app, strategy):
+        """대조(회귀 방지): HIL 활성 그래프에서는 동일 입력이 human_review에서 interrupt된다"""
+        config = {"configurable": {"thread_id": f"hil-enabled-{strategy}"}}
+        result = self._invoke(hil_app, strategy, config=config)
+
+        assert "__interrupt__" in result    # 활성 그래프는 동일 입력에서 중단
+        assert result["__interrupt__"][0].value["strategy"] == strategy
+        assert result.get("final_response") is None # 조기 중단되어 응답 미생성

--- a/tests/unit/agent/test_hil_workflow.py
+++ b/tests/unit/agent/test_hil_workflow.py
@@ -45,7 +45,7 @@ def hil_app():
 
 @pytest.fixture
 def hil_disabled_workflow():
-    """checkpointer 없이 컴파일해 HIL을 비활성화한 단발성 실행 워크플로우 (단위 테스트용, #92).
+    """checkpointer 없이 컴파일해 HIL을 비활성화한 단발성 실행 워크플로우
 
     checkpointer가 없으면 build_workflow가 human_review를 hil_enabled=False로 바인딩하므로
     decompose/stepback 질의도 interrupt 없이 search로 통과한다.
@@ -248,7 +248,7 @@ class TestRunResumeWorkflow:
         assert resumed["final_response"] is not None # 최종 응답 생성 확인
 
 
-# ── HIL 비활성화 경로 (#92): 단위 테스트용 단발성 실행 ──────────────────────────
+# ── HIL 비활성화 경로: 단위 테스트용 단발성 실행 ──────────────────────────
 
 @pytest.mark.unit
 class TestHumanReviewHILDisabled:


### PR DESCRIPTION
## 개요

단위 테스트 한정으로 HIL(Human-in-the-Loop, 조건부 `interrupt()`)을 비활성화하는 실행 경로를 도입합니다. `#79`로 도입된 리라이트 노드 HIL 때문에 `decompose`/`stepback` 전략 질의는 `human_review`에서 `interrupt()`로 중단되는데, HIL과 무관한 로직(검색·grounding·답변 생성 등)을 빠르고 결정적으로 격리 검증해야 하는 단위 테스트에서는 interrupt/resume 왕복 없이 그래프를 끝까지 단발성으로 돌릴 경로가 필요합니다. 이것이 `#90` 본문에서 "대안"으로 언급된 **방식 B(테스트 한정 HIL 비활성화)** 이며, 본 PR에서 다룹니다.

> 역할 분리: **벤치마크/통합 = 방식 A(#90, auto-resume)** / **단위 = 방식 B(본 PR)**. 두 방식은 폐기 관계가 아니라 용도별 이중 트랙입니다.

Closes #92

---

## 변경 사항

### 수정

- **`src/agent/workflow.py`**
  - `human_review`에 `hil_enabled: bool = True` 키워드 인자 추가 — `False`면 전략과 무관하게 `interrupt()` 없이 통과(빈 dict 반환)
  - `build_workflow`가 `checkpointer is not None` 결과를 `partial(human_review, hil_enabled=...)`로 바인딩 — checkpointer 부재 시 HIL 비활성화
- **`tests/unit/agent/test_hil_workflow.py`**
  - `hil_disabled_workflow` fixture 추가 (`build_workflow(checkpointer=None)`)
  - `TestHumanReviewHILDisabled` — `human_review(hil_enabled=False)`가 decompose/stepback도 통과하는지 검증
  - `TestHILDisabledGraph` — 비활성화 그래프에서 HIL 전략이 interrupt 없이 단발성 완료되는지 + HIL 활성 그래프는 동일 입력에서 interrupt되는지 대조 검증

---

## 아키텍처

### 설계 결정: 방식 1 (`checkpointer=None`) 채택

이슈가 제시한 두 후보(`checkpointer=None` vs `enable_hil` 파라미터) 중 **방식 1**을 채택했습니다.

| 근거 | 설명 |
|------|------|
| LangGraph 의미론과 일치 | `interrupt()`는 checkpointer 없이는 호출 자체가 불가(런타임 에러). "checkpointer 부재 = HIL 불가"는 LangGraph가 이미 강제하는 제약이며, 이를 명시적 분기로 표현 |
| 잠재 버그 동시 해소 | 기존 코드는 `build_workflow(checkpointer=None)`로 컴파일은 되나, decompose/stepback 질의 진입 시 `human_review`가 `interrupt()`를 호출해 **런타임 에러** 발생. 본 PR이 이 결함을 함께 수정 |
| API 표면 최소화·대칭성 | 새 파라미터 없이 기존 시그니처로 해결. 기존 `hil_app`(checkpointer 有)과 신규 `hil_disabled_workflow`(checkpointer 無)가 자연스러운 대조쌍을 형성 |

방식 2(`enable_hil` 플래그)는 `checkpointer`와 직교하는 두 번째 축을 만들어 `checkpointer=None + enable_hil=True` 같은 여전히 에러나는 조합을 허용하는 단점이 있어 배제했습니다.

### 실행 흐름 대비

```text
[프로덕션 / HIL 활성]  checkpointer=MemorySaver
  rewrite → human_review ──(decompose/stepback)──> interrupt() 중단 → resume 필요

[단위 테스트 / HIL 비활성]  checkpointer=None
  rewrite → human_review ──(전략 무관)──> pass-through → search → ... → generate (단발성 완료)
```

**프로덕션 기본 동작(HIL 활성)은 변경 없음** — 비활성화는 테스트가 `checkpointer=None`으로 명시적으로 옵트인할 때만 적용됩니다.

---

## 체크리스트

- [x] `build_workflow`에 HIL 비활성화 모드 추가 (`checkpointer=None` 경로, 근거 명시)
- [x] 프로덕션 기본 경로(HIL 활성)가 영향받지 않음을 단위 테스트로 보장 (대조 테스트)
- [x] `hil_disabled_workflow` fixture 추가 및 단위 테스트 작성
- [x] decompose/stepback 입력에서 비활성화 시 통과 / 활성 시 interrupt 대조 테스트
- [x] 단위 테스트 전체 통과 (`tests/unit/agent` 137 passed, 신규 6건 포함)

## 참고

- 관련 이슈: #79(HIL 도입), #90(벤치마크 auto-resume 방식 A)
- 핵심 진입점: `src/agent/workflow.py`의 `build_workflow`, `human_review`
