### PR TITLE
test: 청킹↔온톨로지 매핑 무결성 통합 테스트 추가 및 ingestion 실모듈 관통 재작성 (#97)

### DIFF
--- a/src/db/vector_store.py
+++ b/src/db/vector_store.py
@@ -227,8 +227,8 @@ def similarity_search(query_vector: list[float], top_k: int, collection: str) ->
 def delete_collection(collection: str) -> bool:
     """지정한 컬렉션의 모든 벡터를 삭제한다. 성공 시 True, 실패 시 False를 반환한다.
 
-    테이블 자체는 유지하고 행만 비운다(DELETE). 재인덱싱 시 _ensure_collection()을
-    다시 태울 필요가 없고, HNSW 인덱스 정의도 보존된다.
+    테이블 자체는 유지하고 행만 비운다(DELETE). 
+    재인덱싱 시 _ensure_collection()을 다시 태울 필요가 없고, HNSW 인덱스 정의도 보존된다.
     """
     try:
         with get_pool().connection() as conn:

--- a/src/utils/embedding.py
+++ b/src/utils/embedding.py
@@ -20,8 +20,7 @@ _lock = threading.Lock()    # 멀티스레드 환경에서 모델 이중 로드 
 def _get_model():
     """SentenceTransformer 모델을 lazy 싱글톤으로 반환한다.
 
-    - 지연 임포트: sentence_transformers는 torch를 끌고 오므로 모듈 import 시점이 아닌
-      최초 임베딩 시점에 로드하여, DB 전용 경로(예: sparse 검색)의 기동 비용을 막는다.
+    - 지연 임포트: sentence_transformers는 torch를 끌고 오므로 모듈 import 시점이 아닌 최초 임베딩 시점에 로드하여, DB 전용 경로(예: sparse 검색)의 기동 비용을 막는다.
     - _lock으로 보호해 동시 호출 시 모델이 두 번 로드되지 않도록 한다.
     """
     global _model

--- a/tests/integration/ingestion/conftest.py
+++ b/tests/integration/ingestion/conftest.py
@@ -1,0 +1,69 @@
+"""ingestion 통합 테스트# 전용 픽스처.
+
+이 디렉터리의 테스트는 외부 의존(파싱·임베딩·DB)만 모킹하고 실제 청킹(chunk_graph)·인덱싱(index_documents) 모듈을 그대로 관통한다.
+따라서 라이브 인프라(Docker/모델 다운로드)없이 통과해야 한다.
+
+상위 `tests/integration/conftest.py`의 세션 게이트(`check_integration_env`)는
+OPENAI_API_KEY·Docker 인프라가 없으면 통합 테스트 전체를 skip시키는데, 
+트랙 B는 그런 의존이 없으므로 동명 픽스처로 오버라이드하여 게이트를 무력화한다.
+pytest는 테스트와 더 가까운 conftest에 정의된 동명 픽스처를 우선 사용한다.
+"""
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src.utils.config import EMBEDDING_DIM
+
+
+@pytest.fixture(scope="session", autouse=True)
+def check_integration_env():
+    """상위 conftest의 인프라/환경 게이트를 무력화하는 동명 오버라이드.
+
+    트랙 B는 외부 의존을 전부 모킹하므로 OPENAI_API_KEY·Docker 점검을 건너뛰고
+    라이브 인프라 없이 통과해야 한다.
+    """
+    yield
+
+
+@pytest.fixture
+def mock_db_pool():
+    """psycopg3 커넥션 풀과 커서를 mock한다.
+
+    `tests/unit/db/test_vector_store.py`의 동명 픽스처를 ingestion conftest로 승격해 재사용한다.
+    """
+    with patch("src.db.vector_store.get_pool") as mock_get_pool:
+        mock_pool = MagicMock()
+        mock_conn = MagicMock()
+        mock_cur = MagicMock()
+
+        mock_get_pool.return_value = mock_pool
+        mock_pool.connection.return_value.__enter__.return_value = mock_conn
+        mock_conn.cursor.return_value.__enter__.return_value = mock_cur
+
+        yield mock_cur
+
+
+@pytest.fixture
+def mock_embedding():
+    """KURE-v1 임베딩(embed_texts)·토큰 계산(count_tokens)을 mock한다.
+
+    `tests/unit/db/test_vector_store.py`의 동명 픽스처를 ingestion conftest로 승격해 재사용한다.
+    """
+    with patch("src.db.vector_store.embed_texts") as mock_embed, \
+         patch("src.db.vector_store.count_tokens") as mock_count:
+        mock_embed.side_effect = lambda texts, node="index": [[0.1] * EMBEDDING_DIM for _ in texts] # 0.1이 EMBEDDING_DIM(1536)개 들어있는 플로팅 넘버 리스트(벡터)를 만들기 위해
+        mock_count.return_value = 10    # 기본: 토큰 한도 이내
+        yield mock_embed, mock_count
+
+
+@pytest.fixture(autouse=True)
+def _close_pool_teardown():
+    """각 테스트 종료 시 전역 커넥션 풀을 명시적으로 닫아 `_pool` 누출을 방지한다.
+
+    get_pool은 mock으로 차단되어 실제 풀이 열리지 않는 것이 정상이지만, 어떤 경로로든
+    init_pool이 호출된 경우를 대비해 teardown에서 close_pool()을 안전하게 호출한다.
+    """
+    yield
+    from src.db.connection import close_pool
+
+    close_pool()

--- a/tests/integration/ingestion/test_ingestion_pipeline.py
+++ b/tests/integration/ingestion/test_ingestion_pipeline.py
@@ -1,58 +1,44 @@
 """
-[데이터 수집 파이프라인 통합 테스트]
+[데이터 수집 파이프라인 통합 테스트
 
-문서 파싱(Docling) → 온톨로지 그래프 구축(Apache AGE) → 벡터 인덱싱(pgvector)
-연쇄 동작에서 다양한 입력 조건(정상, 경계값, 예외)에 따른 데이터 전달 정합성과 상태 진화를 검증합니다.
+문서 파싱(Docling) → 온톨로지 그래프 → 청킹(FUNC-002/003) → 벡터 인덱싱(pgvector)
+연쇄 동작에서 데이터 전달 정합성과 상태 진화를 검증한다.
 
 설계 원칙:
-    - pytest.mark.parametrize로 문서 유형, 크기, 예외 상황을 다양하게 주입하여 Ingestion 파이프라인의 견고함을 검증합니다.
-    - 개별 스키마가 아닌, Parse → Chunk → Index 전체 흐름을 하나의 테스트에서 관통하며 데이터 손실 여부를 추적합니다.
+    - 외부 의존(파싱·임베딩·DB)만 모킹하고 실제 청킹·인덱싱 모듈을 그대로 관통한다.
+      청킹은 `src.db.ontology.chunker.chunk_graph`, 인덱싱은 `src.db.vector_store.index_documents`를 모킹 없이 호출하여, 시뮬레이션 헬퍼가 가렸던 실제 데이터 흐름의 정합성을 검증한다.
+    - 라이브 인프라(Docker/모델 다운로드) 없이 통과한다. 임베딩·DB·파서는 conftest 픽스처로 차단하고, 청킹 토큰 카운터는 모델 로드를 피하려고 가벼운 단어 수 함수를 주입한다.
+    - 온톨로지 그래프는 LLM 빌드(build_graph) 대신 git에 추적되는 `data/ontology/*.json`을 역직렬화해 입력한다. 이는 main.py의 기본 ingest 경로(미리 빌드된 온톨로지 JSON 적재)와 동일하다.
 """
+from contextlib import contextmanager
+from pathlib import Path
+from unittest.mock import patch
+
 import pytest
-from src.models.schemas import ParsedDocument, IndexingResult, RetrievedChunk
+
+from src.db.ontology.chunker import chunk_graph
+from src.db.ontology.models import OntologyGraph
+from src.db.vector_store import index_documents
+from src.models.schemas import ParsedDocument
+from src.parse.parser import DoclingParser
+
+# 온톨로지 JSON 디렉터리, 청킹 입력 그래프의 출처
+ONTOLOGY_DIR = Path(__file__).resolve().parents[2].parent / "data" / "ontology"
 
 
-# ── Mock 데이터 팩토리 ──
+def _word_count(text: str) -> int:
+    """모델 로드를 피하는 가벼운 토큰 카운터 — 공백 기준 단어 수.
 
-def make_parsed_document(
-    title: str,
-    sections: list[str],
-    tables: list[dict] | None = None,
-    metadata: dict | None = None,
-) -> ParsedDocument:
-    """테스트용 ParsedDocument 생성"""
-    return ParsedDocument(
-        title=title,
-        text="\n".join(sections),
-        tables=tables or [],
-        metadata=metadata or {"source": f"data/{title}.pdf"}
-    )
+    청킹의 토큰 한도 분할은 chunker 단위 테스트가 검증하므로,
+    통합 테스트에서는 KURE-v1 토크나이저 대신 이 함수를 주입해 인프라 없이 결정적으로 동작시킨다.
+    """
+    return len(text.split())
 
 
-def simulate_chunking(doc: ParsedDocument) -> list[RetrievedChunk]:
-    """ParsedDocument를 청크로 분할하는 시뮬레이션"""
-    return [
-        RetrievedChunk(
-            chunk_id=f"chunk-{i}",
-            document_id=f"DOC-{doc.title}",
-            content=section,
-            score=0.0,
-            metadata={"source": doc.metadata.get("source", "unknown")}
-        )
-        for i, section in enumerate(doc.text.split("\n"))
-        if section.strip()
-    ]
-
-
-def simulate_indexing(doc_id: str, chunk_count: int, *, force_status: str | None = None) -> IndexingResult:
-    """인덱싱 결과 시뮬레이션"""
-    if force_status:
-        status = force_status
-    elif chunk_count == 0:
-        status = "failed"
-    else:
-        status = "success"
-    return IndexingResult(document_id=doc_id, chunk_count=chunk_count, status=status)
+def _load_graph(chapter: str) -> OntologyGraph:
+    """data/ontology/<chapter>.json을 OntologyGraph로 역직렬화한다."""
+    path = ONTOLOGY_DIR / f"{chapter}.json"
+    return OntologyGraph.model_validate_json(path.read_text(encoding="utf-8"))
 
 
 # ── 전체 Ingestion 파이프라인 ──
@@ -62,124 +48,135 @@ class TestIngestionPipeline:
     """Parse → Chunk → Index 연쇄 데이터 흐름의 상태 진화 검증"""
 
     @pytest.mark.parametrize(
-        "title, sections, tables, expected_chunk_count, expected_status",
+        "chapter, expected_status",
         [
-            # 케이스 1: 표준 문서 — 2개 섹션, 표 없음 → 정상 인덱싱
-            (
-                "일반기업회계기준_제10장",
-                ["10.1 유형자산의 정의: 영업활동에 사용할 목적으로 보유하는 자산",
-                 "10.22 재평가 주기: 3~5년 내 재평가 실시 권고"],
-                [],
-                2,
-                "success",
-            ),
-            # 케이스 2: 표 포함 문서 — 텍스트 3개 섹션 + 표 1개 → 정상 인덱싱
-            (
-                "일반기업회계기준_제6장",
-                ["6.1 적용 범위: 금융자산·금융부채의 인식과 측정",
-                 "6.2 금융자산의 분류: 당기손익인식, 매도가능, 만기보유, 대여금 및 수취채권",
-                 "6.3 최초 인식: 공정가치로 측정"],
-                [{"headers": ["구분", "내용"], "rows": [["유동", "1년 이내"]]}],
-                3,
-                "success",
-            ),
-            # 케이스 3: 대용량 문서 — 10개 섹션 → 정상 인덱싱
-            (
-                "일반기업회계기준_전체",
-                [f"제{i}장 내용: 회계 기준서의 제{i}장에 해당하는 상세 내용입니다." for i in range(1, 11)],
-                [],
-                10,
-                "success",
-            ),
-            # 케이스 4: 빈 본문 문서 — 섹션 0개 → 인덱싱 실패
-            (
-                "빈_문서",
-                [],
-                [],
-                0,
-                "failed",
-            ),
-            # 케이스 5: 본문은 없지만 표만 있는 문서 → 청크 0개, 인덱싱 실패
-            (
-                "표만_있는_문서",
-                [],
-                [{"headers": ["계정", "금액"], "rows": [["매출채권", "100,000"]]}],
-                0,
-                "failed",
-            ),
+            # gaap-ch1: content 노드 3개 → 청크 3개, 전량 적재 성공
+            ("gaap-ch1", "success"),
+            # gaap-ch6: content 노드 200개 → 다수 청크, 전량 적재 성공 (배치 분할 포함)
+            ("gaap-ch6", "success"),
         ],
-        ids=["standard_doc", "doc_with_tables", "large_doc", "empty_doc", "table_only_doc"]
+        ids=["small_chapter", "large_chapter"],
     )
     def test_parse_to_chunk_to_index_flow(
-        self, title, sections, tables, expected_chunk_count, expected_status
+        self, chapter, expected_status, mock_db_pool, mock_embedding
     ):
-        """문서의 유형과 크기에 따라 Parse → Chunk → Index 파이프라인이
-        데이터 손실 없이 올바르게 동작하는지 검증"""
+        """실제 온톨로지 JSON을 입력으로 Parse → Chunk → Index 파이프라인이 데이터 손실 없이(고아 청크 0건) 동작하는지 검증."""
 
-        # Parse 단계
-        doc = make_parsed_document(title=title, sections=sections, tables=tables)
-        assert doc.title == title
-        assert len(doc.tables) == len(tables)
+        # Parse 단계 — DoclingParser.parse를 모킹해 FUNC-001 출력 스펙(source_path)을 재현
+        source_path = f"data/raw/{chapter}.pdf"
+        with patch_parser(source_path):
+            parsed = DoclingParser().parse(source_path)
+        assert parsed.metadata["source_path"] == source_path
 
-        # Chunk 단계
-        chunks = simulate_chunking(doc)
-        assert len(chunks) == expected_chunk_count
+        # Chunk 단계 — 실제 chunk_graph 관통 (그래프는 JSON 역직렬화로 입력)
+        graph = _load_graph(chapter)
+        chunks = chunk_graph(
+            graph,
+            source_path=parsed.metadata["source_path"],
+            token_counter=_word_count,
+        )
+        assert len(chunks) > 0
 
-        # 데이터 무결성: 청크의 source 메타데이터가 원본 문서에서 전달됨
-        for chunk in chunks:
-            assert chunk.metadata.model_extra["source"] == doc.metadata["source"]
+        # 데이터 무결성: 고아 청크 0건 — 모든 청크가 ontology_node_id를 보유
+        assert all(c.metadata.ontology_node_id for c in chunks)
+        # source 메타데이터가 파싱 → 청크까지 전달됨 (spec: "source" → "source_path")
+        assert all(c.metadata.model_extra["source_path"] == source_path for c in chunks)
 
-        # Index 단계
-        result = simulate_indexing(f"DOC-{title}", len(chunks))
-        assert result.chunk_count == expected_chunk_count
+        # Index 단계 — 실제 index_documents 관통 (임베딩·DB는 모킹)
+        result = index_documents(chunks, collection="test_collection")
         assert result.status == expected_status
+        assert result.chunk_count == len(chunks)
+        assert result.document_id == chunks[0].document_id
 
+    def test_empty_graph_yields_failed_indexing(self, mock_db_pool, mock_embedding):
+        """content 노드가 없는 그래프 → 청크 0개 → 인덱싱 failed (실모듈 관통)."""
+        chunks = chunk_graph(
+            OntologyGraph(),
+            document_id="DOC-EMPTY",
+            token_counter=_word_count,
+        )
+        assert chunks == []
+
+        result = index_documents(chunks, collection="test_collection")
+        assert result.chunk_count == 0
+        assert result.status == "failed"
 
     @pytest.mark.parametrize(
-        "chunk_count, force_status",
+        "scenario, expected_status, expected_count",
         [
-            (25, "success"),
-            (10, "partial"),
-            (0, "failed"),
+            ("success", "success", 3),    # 모든 배치 성공
+            ("partial", "partial", 2),    # 중간 배치 1개만 DB 오류 → 부분 커밋
+            ("failed", "failed", 0),      # 빈 입력 → 적재 대상 없음
         ],
-        ids=["full_success", "partial_failure", "complete_failure"]
+        ids=["full_success", "partial_failure", "complete_failure"],
     )
-    def test_indexing_status_by_result(self, chunk_count, force_status):
-        """인덱싱 결과의 status가 청크 수와 처리 상태에 따라 올바르게 설정되는지 검증"""
+    def test_indexing_status_by_result(
+        self, scenario, expected_status, expected_count, mock_db_pool, mock_embedding
+    ):
+        """실제 index_documents의 success / partial / failed 3상태를 실동작 기반으로 검증.
 
-        result = simulate_indexing("DOC-TEST", chunk_count, force_status=force_status)
-        assert result.status == force_status
-        assert result.chunk_count == chunk_count
+        partial은 단위 테스트가 토큰 한도 스킵 케이스를 이미 검증하므로, 여기서는
+        배치 경계 케이스(배치 단위 부분 커밋) 1건으로 충분하다.
+        """
+        if scenario == "failed":
+            # 빈 입력은 DB 접근 없이 즉시 failed
+            result = index_documents([], collection="test_collection")
+            assert result.status == expected_status
+            assert result.chunk_count == expected_count
+            return
 
-        # partial이면 일부만 성공했으므로 chunk_count > 0
-        if force_status == "partial":
-            assert result.chunk_count > 0
-        # failed이면 인덱싱된 청크가 없어야 함
-        if force_status == "failed":
-            assert result.chunk_count == 0
+        chunks = chunk_graph(_load_graph("gaap-ch1"), token_counter=_word_count)
+        assert len(chunks) == 3
 
+        if scenario == "partial":
+            # 배치 크기 1 → 3개 배치 중 두 번째 배치만 DB 오류로 실패시킨다.
+            # 부분 커밋 정책상 1·3번째 배치는 유지되어 chunk_count=2, status=partial.
+            mock_db_pool.executemany.side_effect = [None, Exception("일시 장애"), None]
+            with patch("src.db.vector_store.BATCH_SIZE", 1):
+                result = index_documents(chunks, collection="test_collection")
+        else:
+            result = index_documents(chunks, collection="test_collection")
 
-    def test_metadata_propagation_through_pipeline(self):
-        """문서 메타데이터(source, standard, page_count)가 파이프라인 전체를 관통하여
-        최종 청크까지 보존되는지 검증"""
+        assert result.status == expected_status
+        assert result.chunk_count == expected_count
 
-        metadata = {
-            "source": "data/K-GAAP_제10장.pdf",
-            "standard": "K-GAAP",
-            "page_count": 42
-        }
-        doc = make_parsed_document(
-            title="메타데이터_테스트",
-            sections=["10.1 유형자산 정의", "10.2 감가상각"],
-            metadata=metadata
+    def test_metadata_propagation_through_pipeline(self, mock_db_pool, mock_embedding):
+        """문서 메타데이터(source_path)와 온톨로지 식별자(standard_type·chapter)가  파이프라인 전체를 관통하여 최종 청크까지 보존되는지 검증."""
+
+        source_path = "data/raw/K-GAAP_제6장.pdf"
+        with patch_parser(source_path):
+            parsed = DoclingParser().parse(source_path)
+
+        graph = _load_graph("gaap-ch6")
+        chunks = chunk_graph(
+            graph,
+            source_path=parsed.metadata["source_path"],
+            token_counter=_word_count,
         )
 
-        chunks = simulate_chunking(doc)
+        # 모든 청크에 원본 source_path 보존
+        assert all(c.metadata.model_extra["source_path"] == source_path for c in chunks)
+        # standard_type·chapter는 Standard 노드 기준으로 전 청크에 전파
+        assert all(c.metadata.standard_type == "GAAP" for c in chunks)
+        assert all(c.metadata.chapter == "6" for c in chunks)
+        # 같은 문서의 청크는 동일한 document_id (Standard 노드 id 기준)
+        assert {c.document_id for c in chunks} == {"gaap-ch6"}
 
-        # 모든 청크에 원본 메타데이터의 source가 보존
-        for chunk in chunks:
-            assert chunk.metadata.model_extra["source"] == metadata["source"]   # metadata.model_extra.source 명시 필드 검증
 
-        # document_id가 일관되게 부여
-        doc_ids = {chunk.document_id for chunk in chunks}
-        assert len(doc_ids) == 1  # 같은 문서의 청크는 동일한 document_id
+# ── 헬퍼 ──
+
+
+@contextmanager
+def patch_parser(source_path: str):
+    """DoclingParser.parse를 모킹해 ParsedDocument를 반환한다.
+
+    parser 실제 스펙(`src/parse/parser.py`)대로 metadata={"source_path": ...}를 싣는다.
+    """
+    parsed = ParsedDocument(
+        title=Path(source_path).stem,
+        text="(parsing mocked)",
+        tables=[],
+        metadata={"source_path": source_path},
+    )
+    with patch.object(DoclingParser, "parse", return_value=parsed):
+        yield

--- a/tests/integration/test_chunk_node_mapping.py
+++ b/tests/integration/test_chunk_node_mapping.py
@@ -1,0 +1,128 @@
+"""
+[청킹 ↔ 온톨로지 노드 매핑 무결성 통합 테스트]
+
+청킹 → 인덱싱 → 검색 → 온톨로지 노드 조회로 이어지는 연동 경로를, 라이브 pgvector 컨테이너와 실제 KURE-v1 임베딩으로 1회 관통하며 chunk_id ↔ node_id 매핑 무결성을 검증한다.
+
+검증 항목:
+    - 고아 청크 0건: 인덱싱된 모든 청크가 1개 이상의 온톨로지 노드에 매핑된다(ontology_node_id 보유)
+    - dangling 참조 0건: 검색 결과 청크의 ontology_node_id가 실제 OntologyNode.id로 해소된다.
+    - Subsection 노드의 paragraphs 정보와 청크 content의 정합성(샘플)
+    - ontology_bridge 폴백: 매핑 없는 청크는 예외 없이 빈 매핑으로 처리된다.
+
+전제:
+    - 라이브 인프라(pgvector 컨테이너)·KURE-v1 모델이 필요하다. 인프라/환경이 없으면 상위
+      tests/integration/conftest.py의 check_integration_env가 세션 단위로 skip 처리한다.
+    - 적재는 검색기와 공유하는 운영 테이블을 오염시키지 않도록 전용 테스트 컬렉션을 쓰고,
+      teardown에서 비운다(데이터 격리).
+    - 온톨로지 그래프는 LLM 빌드 대신 git에 추적되는 data/ontology/*.json을 역직렬화해 입력한다.
+"""
+from pathlib import Path
+
+import pytest
+
+from src.db.connection import close_pool, init_pool
+from src.db.ontology.chunker import chunk_graph
+from src.db.ontology.models import OntologyGraph
+from src.db.vector_store import delete_collection, index_documents, similarity_search
+from src.models.schemas import RetrievedChunk
+from src.retrieval.ontology_bridge import chunks_to_node_ids
+from src.utils.embedding import embed_texts
+
+ONTOLOGY_DIR = Path(__file__).resolve().parents[2] / "data" / "ontology"
+CHAPTER = "gaap-ch1"                          # content 노드 3개로 적재·검색이 가볍다
+TEST_COLLECTION = "chunks_test_ch1_mapping"   # 운영 chunks 테이블과 분리된 전용 컬렉션
+SOURCE_PATH = f"data/ontology/{CHAPTER}.json"
+
+
+@pytest.fixture(scope="class")
+def indexed_chapter():
+    """gaap-ch1을 청킹 → 인덱싱하여 전용 컬렉션에 적재하고 (graph, chunks)를 제공한다.
+
+    teardown에서 delete_collection으로 적재분을 비워 운영 데이터 오염과 테스트 간 누출을 막는다.
+    """
+    graph = OntologyGraph.model_validate_json(
+        (ONTOLOGY_DIR / f"{CHAPTER}.json").read_text(encoding="utf-8")
+    )
+    # 라이브 테스트는 main.py와 달리 풀 초기화가 자동으로 일어나지 않으므로 직접 연다.
+    init_pool()
+    try:
+        # 적재 직전 잔여 행 정리 후 재적재 (멱등 보장)
+        delete_collection(TEST_COLLECTION)
+
+        chunks = chunk_graph(graph, source_path=SOURCE_PATH)
+        assert chunks, "청킹 결과가 비어 있으면 매핑 검증을 진행할 수 없다"
+
+        result = index_documents(chunks, collection=TEST_COLLECTION)
+        assert result.status == "success", f"적재 실패: {result.status}"
+        assert result.chunk_count == len(chunks)
+
+        yield graph, chunks
+    finally:
+        delete_collection(TEST_COLLECTION)
+        close_pool()
+
+
+@pytest.mark.system
+class TestChunkNodeMapping:
+    """chunk_id ↔ node_id 매핑 무결성 검증 (라이브 pgvector)"""
+
+    def test_no_orphan_chunks(self, indexed_chapter):
+        """모든 인덱싱된 청크가 1개 이상의 노드에 매핑된다 (고아 청크 0건)."""
+        _, chunks = indexed_chapter
+        orphans = [c.chunk_id for c in chunks if not c.metadata.ontology_node_id]
+        assert not orphans, f"고아 청크 발견(ontology_node_id 없음): {orphans}"
+
+    def test_search_node_ids_resolve_to_real_nodes(self, indexed_chapter):
+        """검색 결과 청크의 ontology_node_id가 실제 OntologyNode.id로 올바르게 연결하고 있는지 검증"""
+        graph, chunks = indexed_chapter
+        node_ids = {n.id for n in graph.nodes}
+
+        query_vector = embed_texts(["일반기업회계기준의 목적과 적용 범위"], node="search")[0]
+        results = similarity_search(query_vector, top_k=5, collection=TEST_COLLECTION)
+        assert results, "검색 결과가 비어 있으면 매핑 무결성을 검증할 수 없다"
+
+        # 검색 결과의 모든 ontology_node_id가 그래프에 실재하는지 — 실패 시 문제 쌍을 식별
+        dangling = [
+            (r.chunk_id, r.metadata.ontology_node_id)
+            for r in results
+            if r.metadata.ontology_node_id not in node_ids
+        ]
+        assert not dangling, f"dangling node_id 참조(chunk_id, node_id): {dangling}"
+
+        # ontology_bridge의 그래프 탐색 진입점도 전부 실재 노드여야 한다
+        entry_node_ids = chunks_to_node_ids(results)
+        assert entry_node_ids, "검색 결과에서 진입 노드 ID를 하나도 추출하지 못했다"
+        assert all(nid in node_ids for nid in entry_node_ids)
+
+    def test_subsection_paragraph_consistency(self, indexed_chapter):
+        """Subsection 노드의 paragraphs 문단 번호가 대응 청크 content에 등장하는지 샘플 검증."""
+        graph, chunks = indexed_chapter
+        # gaap-ch1은 노드↔청크 1:1(분할 없음)이므로 ontology_node_id로 청크를 찾는다
+        chunk_by_node: dict[str, RetrievedChunk] = {}
+        for c in chunks:
+            chunk_by_node.setdefault(c.metadata.ontology_node_id, c)
+
+        subsections = [
+            n for n in graph.nodes
+            if n.node_type == "Subsection" and n.paragraphs and n.id in chunk_by_node
+        ]
+        assert subsections, "paragraphs를 가진 Subsection 노드를 찾지 못했다"
+
+        for node in subsections:
+            chunk = chunk_by_node[node.id]
+            present = [p for p in node.paragraphs if p in chunk.content]
+            assert present, (
+                f"노드 {node.id}의 문단 번호 {node.paragraphs}가 청크 content에 없음: "
+                f"{chunk.content[:60]!r}"
+            )
+
+    def test_ontology_bridge_fallback_on_unmapped_chunk(self):
+        """매핑 정보가 없는 청크는 예외 없이 빈 매핑으로 처리된다 (ontology_bridge 폴백)"""
+        unmapped = RetrievedChunk(
+            chunk_id="unmapped-1",
+            document_id="DOC-X",
+            content="온톨로지 노드에 매핑되지 않은 청크",
+            score=0.1,
+        )
+        # ontology_node_id가 없으므로 Silent Skip → 빈 리스트, 예외 없음
+        assert chunks_to_node_ids([unmapped]) == []


### PR DESCRIPTION
## 개요

#97 을 구현합니다. 청킹 → 인덱싱 → 검색 → 온톨로지 노드 조회로 이어지는 연동 경로에서 **chunk_id ↔ node_id 매핑 무결성**을 검증하는 통합 테스트가 없던 공백을 메웁니다. E2E(#95)·벤치마크(#96)에 앞서 매핑 무결성을 보장하는 것이 목적입니다.

두 트랙으로 구성됩니다.

- **트랙 A** — 라이브 pgvector + 실제 KURE-v1 임베딩으로 매핑 무결성을 관통 검증
- **트랙 B** — 외부 의존만 모킹하고 실모듈을 관통하는 ingestion 파이프라인 정합성 검증 (구 #61 흡수)

---

## 변경 사항

### 신규 구현

- **`tests/integration/test_chunk_node_mapping.py`** (트랙 A) — 라이브 pgvector 기반 매핑 무결성 통합 테스트 4건
- **`tests/integration/ingestion/conftest.py`** (트랙 B) — 상위 conftest의 인프라 게이트(`check_integration_env`)를 무력화하는 동명 픽스처 + 단위 테스트의 `mock_db_pool`·`mock_embedding` 픽스처 승격 + `close_pool()` teardown

### 수정

- **`tests/integration/ingestion/test_ingestion_pipeline.py`** (트랙 B) — 시뮬레이션 헬퍼 3종을 제거하고 실제 `chunk_graph`·`index_documents`를 관통하도록 전면 재작성
- **`src/db/vector_store.py` / `src/utils/embedding.py`** — docstring 문구 정리 (비기능 변경)

---

## 아키텍처

### 검증 흐름

```text
            트랙 A (라이브 pgvector)                 트랙 B (모킹, 무인프라)
            ─────────────────────                   ─────────────────────
data/ontology/*.json                         DoclingParser.parse (mock)
        │                                             │ source_path
        ▼                                             ▼
   OntologyGraph                              data/ontology/*.json → OntologyGraph
        │                                             │
        ▼  chunk_graph (실제)                          ▼  chunk_graph (실제, 경량 token_counter)
   RetrievedChunk[]                            RetrievedChunk[]
        │                                             │
        ▼  index_documents (실제 임베딩·DB)             ▼  index_documents (실제 / embed·DB는 mock)
   pgvector(전용 컬렉션)                        IndexingResult(success/partial/failed)
        │
        ▼  similarity_search → chunks_to_node_ids
   매핑 무결성 단언 (고아 0 / dangling 0)
```

### 주요 설계 결정

**트랙 B는 라이브 인프라 없이 통과해야 한다**
상위 `tests/integration/conftest.py`의 세션 게이트는 OPENAI_API_KEY·Docker가 없으면 통합 테스트 전체를 skip한다. 트랙 B는 그런 의존이 없으므로 ingestion conftest에 **동명 픽스처를 정의해 게이트를 무력화**한다(pytest는 더 가까운 conftest의 동명 픽스처를 우선 사용). 외부 의존(파서·임베딩·DB)만 모킹하고 청킹·인덱싱 실모듈을 그대로 관통한다.

**온톨로지 그래프는 LLM 빌드 대신 JSON 역직렬화로 입력**
`build_graph`는 LLM 호출을 포함하므로, git에 추적되는 `data/ontology/*.json`을 역직렬화해 결정적·무인프라로 그래프를 공급한다. 이는 `main.py`의 기본 ingest 경로(미리 빌드된 온톨로지 JSON 적재)와 동일하다.

**운영 데이터 격리 (트랙 A)**
검색기와 공유하는 운영 `chunks` 테이블을 오염시키지 않도록 전용 테스트 컬렉션(`chunks_test_ch1_mapping`)에 적재하고, teardown에서 `delete_collection`으로 비운다. 라이브 테스트는 `main.py`와 달리 풀 초기화가 자동으로 일어나지 않으므로 `init_pool()`/`close_pool()`을 명시 관리한다.

**`status` 3상태 실동작 재설계 (트랙 B)**
`test_indexing_status_by_result`를 실제 `index_documents` 동작 기반 success / **partial** / failed 3상태로 재설계했다. partial은 단위 테스트가 토큰 한도 스킵 케이스를 이미 검증하므로, 배치 경계 부분 커밋 케이스 1건으로 검증한다. (`IndexingResult.status`의 `"partial"`은 현행 배치 부분 커밋 설계의 핵심이므로 제거하지 않음 — 구 #61 원안 무효 처리)

---

## 검증 결과

| 실행 | 결과 |
|------|------|
| 트랙 A 라이브 (`test_chunk_node_mapping.py`) | **4 passed** (실제 pgvector + KURE-v1) |
| 트랙 A 인프라 부재 | **4 skipped** (fail 아닌 정상 skip) |
| 트랙 B (`test_ingestion_pipeline.py`) | **7 passed** |
| 트랙 B + `OPENAI_API_KEY=""` + 깨진 DB 호스트 | **7 passed** (무인프라 통과 계약 확인) |
| `tests/integration/ -m system` 전체 | **34 passed**, 42 deselected (마커 deselection 없음) |
| 관련 단위(vector_store·chunker·connection) | **40 passed** |

---

## 체크리스트

- [x] 트랙 A: 고아 청크 0건 / dangling node_id 0건 단언, Subsection paragraphs 정합성, ontology_bridge 폴백 검증
- [x] 트랙 A: 실패 시 문제 `(chunk_id, node_id)` 쌍을 로그로 식별 가능
- [x] 트랙 A: 전용 컬렉션 + teardown 정리로 운영 데이터 격리
- [x] 트랙 B: 시뮬레이션 헬퍼 3종 제거, 실모듈 관통으로 교체
- [x] 트랙 B: `metadata["source"]` → `metadata["source_path"]` 정합, docstring AGE 잔재 제거
- [x] 트랙 B: 라이브 인프라 없이 통과
- [ ] E2E(#95)·벤치마크(#96) 연동 — 후속 진행

---

## 관련 이슈

- Closes #97 (트랙 B로 #61 흡수)
- 관련: #80 (ChunkMetadata), #72 (매핑 레이어), #95 (E2E), #96 (벤치마크)
- 파생: #126 (infra_check.py의 Apache AGE 잔재 정리 — 본 작업 중 발견, 범위 분리)
