### PR TITLE
docs: v1.0 설계·감사 문서 세트 추가 및 ARCHITECTURE superseded 처리

### DIFF
--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -3,7 +3,7 @@
 > Docling + EdgeQuake + LangGraph 기반 회계기준서 RAG 시스템
 >
 > 작성일: 2026-03-21
-> 상태: 초기 설계 (반복 업데이트 예정)
+> 상태: ⚠️ SUPERSEDED — Apache AGE/EdgeQuake/GraphRAG 전제의 초기 설계. AGE는 v1.0에서 제거되고 **pgvector + BM25 하이브리드**로 대체되었습니다. 현행 아키텍처는 [architecture_overview.md](architecture_overview.md)를 참조하세요. 이 문서는 초기 설계 의도 기록용으로만 보존합니다.
 
 ---
 

--- a/docs/architecture_overview.md
+++ b/docs/architecture_overview.md
@@ -1,0 +1,75 @@
+# 아키텍처 개요 (v1.0)
+
+> 회계기준서 RAG 시스템. **pgvector + BM25(tsvector) 하이브리드 검색** 기반.
+> Apache AGE / EdgeQuake / GraphRAG는 v1.0에서 제거됨(초기 설계 문서 `ARCHITECTURE.md`는 superseded).
+> 작성일 2026-06-13 · 코드 실태 기준.
+
+## 1. 한눈에 보기
+
+두 경로를 단일 CLI(`src/main.py`)로 제공한다.
+
+```
+[적재 ingest]
+ PDF/HWP ──(FUNC-001 Docling 파싱)──▶ ParsedDocument(markdown)
+   └▶(FUNC-002 온톨로지 빌드)──▶ OntologyGraph(Standard/Section/Subsection + edges)
+        └▶(FUNC-002 청킹)──▶ RetrievedChunk[]  (metadata.ontology_node_id)
+             └▶(FUNC-003 임베딩 KURE-v1 → pgvector HNSW upsert)──▶ chunks 테이블
+
+[질의 query — LangGraph StateGraph]
+ original_query
+   ─▶ rewrite(FUNC-004) ──┬─(비회계)─▶ early_exit ─▶ END
+                          └─(회계)──▶ human_review(HIL, interrupt)
+   ─▶ search(FUNC-005, dense+sparse RRF)
+   ─▶ rerank(FUNC-006, CrossEncoder · USE_RERANKER 게이트)
+   ─▶ evaluate(FUNC-007, CRAG 자가검증) ──(부족)──▶ rewrite (CRAG 루프, 최대 3회)
+   ─▶ generate(FUNC-008, 답변+인용) ─▶ FinalResponse ─▶ END
+```
+
+## 2. 핵심 결정
+
+| 영역 | 결정 | 근거 |
+|---|---|---|
+| 임베딩 | `nlpai-lab/KURE-v1` (자체호스팅, MIT, 1024차원) | 인덱싱·검색이 `embed_texts()` 공유 → 차원 정합 구조적 보장 |
+| 벡터 인덱스 | pgvector HNSW + `vector_cosine_ops` | 점진 적재(upsert)에 IVFFlat보다 적합 |
+| Sparse 검색 | PostgreSQL `to_tsvector('simple')` + `ts_rank_cd` | ※ 한국어 형태소 미지원·GIN 인덱스 미설정 |
+| 하이브리드 병합 | RRF(Reciprocal Rank Fusion), k=60 | 점수 분포 차이에 강건, 가중치 튜닝 불필요 |
+| LLM | `OPENAI_MODEL`(config) · PydanticAI/OpenAI | rewrite/evaluate/generate 공통 (라이브 검증 필요) |
+| 오케스트레이션 | LangGraph StateGraph + MemorySaver 체크포인터 | HIL interrupt/resume, CRAG 루프 |
+| 상태 공유 | `GraphState`(Pydantic) 증분 merge | 노드는 변경 필드 dict만 반환 |
+
+## 3. 모듈 지도 (실제 구조)
+
+```
+src/
+├── parse/            FUNC-001 — Docling 파싱(parser, layout_config, cluster_merge, reading_order, parser_dtos)
+├── db/
+│   ├── ontology/     FUNC-002 — builder, chunker, md_parser, edge_detector/extractor, resolver, models
+│   ├── vector_store.py  FUNC-003 — pgvector 테이블/HNSW 생성, upsert, 검색
+│   └── connection.py    psycopg 연결풀(init_pool/get_pool/close_pool)
+├── utils/
+│   ├── embedding.py  FUNC-003/005 — KURE-v1 embed_texts (인덱싱·검색 공유)
+│   ├── config.py     전역 상수(모델·임계치·RRF_K·TOP_K 등)
+│   ├── exception.py  커스텀 예외 18종 + 에러코드
+│   └── logger.py     KST 로깅
+├── retrieval/
+│   ├── searcher.py   FUNC-005 — dense_search/sparse_search/RRF/search_chunks
+│   ├── reranker.py   FUNC-006 — CrossEncoder rerank_chunks
+│   └── ontology_bridge.py  검색 청크 → 온톨로지 노드 룩업
+├── agent/
+│   ├── nodes/        FUNC-004/007/008 — rewrite, evaluate, generate
+│   ├── prompts.py    LLM 프롬프트
+│   └── workflow.py   FUNC-009 — StateGraph 정의, 라우팅, HIL, 폴백
+├── models/           schemas.py(공용 Pydantic), state.py(GraphState)
+└── main.py           ingest/query CLI 진입점
+```
+
+> 인터페이스(입출력 타입)·에러코드 카탈로그는 [func_interfaces.md](func_interfaces.md) 참조.
+> 데이터 흐름 다이어그램: `docs/assets/arch-ingest.svg`, `docs/assets/arch-query.svg`.
+
+## 4. 알려진 한계 (v1.0)
+- 전 파이프라인 테스트가 mock — 실데이터 E2E 미검증 (병합 전 스모크 권고)
+- DB 인프라(db.Dockerfile/docker-compose/.env)에 Apache AGE 빌드·로드 잔재
+- Sparse 검색 한국어 형태소 미지원, GIN 인덱스 미설정
+- 크로스챕터 참조는 단일 문서 빌드 한계로 미해소 엣지로 남음
+
+상세 갭·로드맵: [v1_audit_report.md](v1_audit_report.md).

--- a/docs/func_interfaces.md
+++ b/docs/func_interfaces.md
@@ -1,0 +1,96 @@
+# FUNC 인터페이스 명세 (FUNC-001~009)
+
+> v1.0 각 기능의 입출력 계약. 타입은 `src/models/schemas.py`, `src/models/state.py` 기준.
+> 작성일 2026-06-13.
+
+## 데이터 스키마 요약 (`src/models/schemas.py`)
+
+| 스키마 | 필드 |
+|---|---|
+| `ParsedDocument` | title:str, text:str(markdown), tables:list[dict], metadata:dict |
+| `RewrittenQuery` | original_query:str, strategy:str(`hyde`\|`decompose`\|`stepback`\|`bypass`), search_queries:list[str] |
+| `RetrievedChunk` | chunk_id:str, document_id:str, content:str, score:float, metadata:`ChunkMetadata` |
+| `ChunkMetadata` | ontology_node_id, node_type, standard_type, chapter (+extra="allow") |
+| `RerankingResult` | chunk:`RetrievedChunk`, rerank_score:float |
+| `EvaluationResult` | is_relevant:bool, needs_external:bool, confidence:float, reasoning:str |
+| `Citation` | document_id:str, chunk_id:str, content:str, relevance_score:float |
+| `FinalResponse` | answer:str, citations:list[`Citation`], is_answerable:bool, confidence_score:float |
+| `IndexingResult` | document_id:str, chunk_count:int, status(`success`\|`partial`\|`failed`) |
+
+---
+
+## FUNC-001 — 문서 파싱 (`src/parse/`)
+- **입력**: `file_path: str|Path` (PDF). 선택: overlap/containment_threshold(0.15), converter 주입
+- **출력**: `ParsedDocument` (text는 마크다운, tables는 `{headers:[...], rows:[[...]]}`)
+- **진입**: `DoclingParser().parse(path)`
+- **비고**: ⚠️ `ParsedDocument`가 `parser_dtos.py`(dataclass, 실제 반환)와 `schemas.py`(Pydantic)에 이원 정의됨 — 통합 필요.
+
+## FUNC-002 — 청킹/온톨로지 (`src/db/ontology/`)
+- **입력**: 마크다운 경로 또는 `ParsedDocument`
+- **출력**: `OntologyGraph`(노드 `Standard`/`Section`/`Subsection` + edges) → `RetrievedChunk[]`(score=0.0, metadata.ontology_node_id)
+- **진입**: `build_graph(md_path, standard_id, standard_type)` → `chunk_graph(graph, source_path)`
+- **에러**: OT-101(순환참조), OT-102(중복노드), OT-103(구조파싱실패)
+
+## FUNC-003 — 인덱싱 (`src/db/vector_store.py`, `src/utils/embedding.py`)
+- **입력**: `list[RetrievedChunk]`, collection(기본 `chunks`)
+- **출력**: `IndexingResult`
+- **진입**: `index_documents(chunks, collection)`. 임베딩 KURE-v1(1024d) → pgvector HNSW upsert(멱등 chunk_id)
+- **에러**: IX-201(토큰 한도 초과 → 부분 커밋), SE-102(DB)
+
+## FUNC-004 — 질의 재구성 (`src/agent/nodes/rewrite.py`)
+- **입력**: `GraphState`(original_query, standard_filter, human_feedback)
+- **출력(상태 갱신)**: rewritten_query:`RewrittenQuery`, is_accounting_query:bool, classification_confidence:float
+- **진입**: `rewrite_query(state)`. classify_and_select → hyde/decompose/stepback
+- **에러**: CM-002(LLM). ⚠️ 현재 LLM 실패가 silent 폴백
+
+## FUNC-005 — 하이브리드 검색 (`src/retrieval/searcher.py`)
+- **입력**: `query:str`, `top_k:int=10`, `metadata_filter:dict|None`
+- **출력**: `list[RetrievedChunk]`
+- **진입**: `search_chunks(...)` = `dense_search`(pgvector cosine) + `sparse_search`(tsvector) → `reciprocal_rank_fusion(k=60)`
+- **동작**: 한쪽 실패 시 단독 진행, 0건 시 top_k×2 재탐색, 최종 0건 시 SE-103
+- **에러**: SE-101(타임아웃), SE-102(DB), SE-103(결과없음)
+
+## FUNC-006 — 리랭킹 (`src/retrieval/reranker.py`)
+- **입력**: `query:str`, `list[RetrievedChunk]`
+- **출력**: `list[RerankingResult]` (rerank_score 내림차순, RERANK_THRESHOLD=0.5 필터)
+- **진입**: `rerank_chunks(...)`. `USE_RERANKER=False`면 워크플로우가 호출 스킵
+- **에러**: RR-201(모델/점수 실패), RR-202(임계 초과 청크 0건)
+
+## FUNC-007 — 적합성 평가 / CRAG (`src/agent/nodes/evaluate.py`)
+- **입력**: `GraphState`(reranked_chunks/retrieved_chunks)
+- **출력**: evaluation:`EvaluationResult`. needs_external/needs_reretrieval 라우팅 신호
+- **진입**: `evaluate_context(state)`
+- **에러**: EV-301(평가 파싱), EV-302(일관성 위반), EV-303(할루시네이션 감지)
+
+## FUNC-008 — 답변·인용 생성 (`src/agent/nodes/generate.py`)
+- **입력**: `GraphState`(context chunks)
+- **출력**: final_response:`FinalResponse`, retrieval_score, generation_score
+- **진입**: `generate_response(state)`. [n] 인용 추출 + GN-401 인용 가드
+- **에러**: GN-401(응답 포맷), GN-402(컨텍스트 길이 초과)
+
+## FUNC-009 — 워크플로우 제어 (`src/agent/workflow.py`)
+- **상태**: `GraphState`(Pydantic, 증분 merge)
+- **노드/엣지**: rewrite → (early_exit | human_review) → search → rerank → evaluate →(CRAG 루프)→ generate → END
+- **라우팅**: `route_after_rewrite`, `route_after_human_review`, `route_after_evaluate`(needs_reretrieval 최우선)
+- **제어 상수**: MAX_REWRITE_COUNT=3, MAX_HIL_COUNT=5
+- **진입**: `run_workflow(query, standard_filter)`, `resume_workflow(thread_id, decision)`
+- **복원력**: `handle_node_errors` 데코레이터(예외→error_logs 기록 후 계속), GraphRecursionError 폴백. ⚠️ TimeoutError는 재전파, search의 CM-002 오분류
+
+---
+
+## 에러코드 카탈로그 (`src/utils/exception.py`)
+
+| 코드 | 노드 | 의미 | retryable |
+|---|---|---|---|
+| CM-001 | * | 설정/환경변수 누락 | ✗ |
+| CM-002 | * | LLM API 호출 실패 | ✓ |
+| CM-003 | * | 문서 파싱 실패 | ✗ |
+| PS-001/002 | parse | 파일 없음 / 미지원 포맷 | ✗ |
+| OT-101/102/103 | ontology | 순환참조 / 중복노드 / 구조파싱 | ✗ |
+| SE-101/102/103 | search/index | 타임아웃 / DB / 결과없음 | ✓/✓/✗ |
+| RR-201/202 | rerank | 모델실패 / 임계미달 | ✓/✗ |
+| IX-201 | index | 임베딩 토큰 한도 초과 | ✗ |
+| EV-301/302/303 | evaluate | 평가파싱 / 일관성 / 할루시네이션 | ✓/✗/✗ |
+| GN-401/402 | generate | 응답포맷 / 컨텍스트길이 | ✓/✗ |
+
+> `ErrorLog`(timestamp KST, node, error_type, message)로 `GraphState.error_logs`에 누적.

--- a/docs/local_dev_setup.md
+++ b/docs/local_dev_setup.md
@@ -1,0 +1,80 @@
+# 로컬 개발 셋업
+
+> 작성일 2026-06-13. 패키지 매니저는 **uv** 고정.
+
+## 1. 사전 요구
+- Python 3.12+ (`.python-version` 참조)
+- uv (`curl -LsSf https://astral.sh/uv/install.sh | sh`)
+- Docker / Docker Compose (pgvector PostgreSQL용)
+- OpenAI API 키 (rewrite/evaluate/generate 노드용)
+
+## 2. 의존성 설치
+```bash
+uv sync          # .venv 생성 + 의존성(dev 포함) 설치
+```
+> 모든 Python 실행은 `uv run ...`로 한다(예: `uv run pytest`, `uv run python -m src.main ...`).
+
+## 3. 환경 변수
+```bash
+cp .env.example .env
+# .env 편집: OPENAI_API_KEY, POSTGRES_USER/PASSWORD/DB 등
+```
+주요 키:
+
+| 키 | 용도 |
+|---|---|
+| `OPENAI_API_KEY` | LLM 노드 |
+| `POSTGRES_USER` / `POSTGRES_PASSWORD` / `POSTGRES_DB` | DB 접속 |
+| `POSTGRES_HOST` / `POSTGRES_PORT` | 연결 대상 |
+
+> ⚠️ `.env.example`에 남아있는 `AGE_GRAPH_NAME` 등 AGE 레거시 키는 v1.0에서 불필요(#126, 정리 예정).
+> 모델·임계치 등은 `.env`가 아니라 `src/utils/config.py` 상수로 관리(EMBEDDING_MODEL, OPENAI_MODEL, RRF_K, TOP_K_RETRIEVAL, USE_RERANKER ...).
+
+## 4. 데이터베이스 기동
+```bash
+docker compose up -d database
+```
+> 현재 DB 이미지(`db.Dockerfile`)는 pgvector + (레거시) Apache AGE를 빌드한다. AGE 잔재 제거는 #126 진행 중.
+
+## 5. 실행 (진입점 `src/main.py`)
+### 적재(ingest)
+```bash
+# 미리 빌드된 온톨로지 그래프(data/ontology/*.json) 전 챕터 적재
+uv run python -m src.main ingest
+
+# 컬렉션 비우고 재적재
+uv run python -m src.main ingest --reset
+
+# 단일 PDF: 파싱→온톨로지→청킹→적재 전체 경로
+uv run python -m src.main ingest --pdf data/raw/제6장.pdf --standard-id gaap-ch6 --standard-type GAAP
+```
+### 질의(query)
+```bash
+uv run python -m src.main query "금융자산의 최초 인식 시점은?"
+uv run python -m src.main query "리스 회계처리" --standard GAAP
+```
+> HIL interrupt 발생 시 대화형으로 승인/재작성 입력. 비대화형(파이프) 환경은 자동 승인.
+
+## 6. 테스트
+마커 3단계 (`pyproject.toml`):
+
+| 마커 | 의미 | 실행 |
+|---|---|---|
+| `unit` | 외부 의존성 없는 함수 논리 (Phase 0) | `uv run pytest -m unit` |
+| `system` | 가짜 데이터 기반 예외/규격 (Phase 1, Fast Fail) | `uv run pytest -m system` |
+| `benchmark` | 정답셋 기반 답변 품질 (Phase 2, **라이브 DB·LLM 필요**) | `uv run pytest -m benchmark` |
+
+```bash
+uv run pytest tests/unit -q          # 단위 전체 (현재 276 passed)
+uv run pytest -m system -q           # 시스템 (현재 34 passed)
+uv run python tests/run_tests.py     # 통합 러너
+```
+> ⚠️ benchmark/통합 테스트는 `init_pool()` + 적재된 DB가 있어야 통과한다. DB 없이 `tests/integration` 직접 실행 시 검색 실패로 fail한다.
+
+## 7. 컨테이너 안에서 실행
+```bash
+docker compose exec app uv run python -m src.main query "..."
+```
+
+---
+관련 문서: [architecture_overview.md](architecture_overview.md) · [func_interfaces.md](func_interfaces.md) · `docs/docker_setup_guide.md`

--- a/docs/v1_audit_report.md
+++ b/docs/v1_audit_report.md
@@ -1,0 +1,124 @@
+# v1.0 전체 감사 보고서 (FUNC-001~009)
+
+> 기준: `origin/dev` ≡ `test/chunking-search-integration`(동일선상) · 작성일 2026-06-13 (D-1)
+> 방법: FUNC별·프로덕션 차원별 병렬 코드/테스트 감사 + 단위/시스템/통합 테스트 실측 + 적대적 완결성 비평
+
+---
+
+## 0. 종합 판정 — 조건부 병합 가능 (ready_with_minor_gaps)
+
+9개 FUNC 코어 로직은 실제 구현되어 있고 단위 테스트 276 passed로 회귀가 없습니다. **컴파일/런타임을 차단하는 하드 블로커는 없습니다.** 병합 전에 처리할 릴리즈 게이트는 1건입니다.
+
+| 게이트 | 내용 | 권고 |
+|---|---|---|
+| 🔴 라이브 E2E 미검증 | 단위/통합 테스트 전부 mock(임베딩·LLM·리랭커). 실 DB·실 LLM ingest→query 1회 관통 증거 없음. `OPENAI_MODEL='gpt-5.4-mini'` 유효성 미확인 | 병합 직전 1회 라이브 스모크(1개 챕터 ingest → query 1건). 모델 무효 시 즉시 Blocker 승격 |
+
+> **저작권 데이터(과거 #102)**: 기준서 원문·파생 데이터가 PUBLIC git에 추적 중이나, **회계기준원(KASB) 사용 허가 확보** → 게이트 아님(#102 closed가 정상, 재오픈 불필요).
+
+### FUNC 상태 요약
+
+| FUNC | 영역 | 구현 | 테스트 | 판정 |
+|---|---|---|---|---|
+| 001 | 파싱(Docling) | 핵심 완성(레이아웃 후처리·마커병합·표 페이지걸침) | 단위 6/8, 2건 @skip(실 PDF) | 🟡 |
+| 002 | 청킹/온톨로지 | 4단계 파이프라인 완성, 33개 챕터 그래프 | 단위 58 + 통합 4 (고아·dangling 0) | 🟢 |
+| 003 | 인덱싱(임베딩·pgvector) | KURE-v1→HNSW, dense+sparse | 단위 23 + 통합 4 | 🟢 |
+| 004 | 질의 재구성 | classify + hyde/decompose/stepback + HIL | 단위 44 + 계약 2 | 🟡 |
+| 005 | 하이브리드 검색 | dense/sparse 독립장애 + RRF(k=60) | 단위 19 + bridge 6 | 🟡 |
+| 006 | 리랭킹 | CrossEncoder 배치 + USE_RERANKER 게이트 | 단위 14 + 통합 6 (전부 mock) | 🟡 |
+| 007 | 적합성 평가(CRAG) | EV-301/302/303 자가검증 | 단위 27 + 라우팅 통합 | 🟢 |
+| 008 | 답변·인용 생성 | PydanticAI + [n] 인용 추출 | 단위 15 | 🟢 |
+| 009 | 워크플로우 제어 | StateGraph + 조건부 라우팅 3종 + CRAG/HIL | 단위 70+ | 🟡 |
+
+🟡 사유: 001=실 PDF 검증 부재, 004=silent LLM 실패, 005=한국어 형태소 미지원·GIN 없음, 006=실모델 미검증, 009=CM-002 오분류/TimeoutError 미처리.
+
+### 테스트 실측 (2026-06-13)
+
+| 계층 | 결과 | 비고 |
+|---|---|---|
+| 단위(unit) | **276 passed, 5 skipped** | 견고. 단 전부 mock |
+| 시스템(system, fast-fail) | **34 passed, 323 deselected** | 가짜 데이터 예외/규격 검증 |
+| 통합(integration) | **28 failed, 48 passed** | 라이브 DB·적재 부재로 benchmark_compliance 전패(`init_pool` 미호출). NFR-002 정확도 **미측정** |
+
+---
+
+## 1. Phase 2 — v1.0 갭 분석 (심각도/공수)
+
+공수: S(≤0.5d) / M(0.5~1.5d) / L(1.5~3d) / XL(3d+)
+
+### 🔴 릴리즈 게이트 (병합 전 결정)
+
+| # | 항목 | FUNC | 공수 | 근거 |
+|---|---|---|---|---|
+| G2 | 실데이터 E2E + OPENAI_MODEL 라이브 미검증 | 001·003·005·006·007·008·009 | M | 전 테스트 mock, `config.py:13` gpt-5.4-mini |
+
+> ~~G1 저작권 데이터~~ — 회계기준원(KASB) 허가 확보로 해소. data/ 추적은 의도된 상태.
+
+### 🟠 Major (병합 후 fast-follow — 운영 신뢰도 직결)
+
+| # | 항목 | FUNC | 공수 | 근거 |
+|---|---|---|---|---|
+| M1 | search()가 CM-002(임베딩 일시장애)를 SE-103처럼 처리 → CRAG 재시도 누락 | 005·009 | M | `searcher.py:190` embed_query가 try 밖, `workflow.py:232` AccountingRAGError 포획→needs_reretrieval=False |
+| M2 | rewrite LLM 실패 silent (4개 호출부, error_log·로깅 부재) | 004 | M | `rewrite.py:69,106,126,146` bare except + `!TODO` |
+| M3 | DB 인프라 AGE 잔재 (db.Dockerfile/compose/.env/infra_check) — 결정과 모순 + 통합테스트 부당 skip(#126) | infra | M | `db.Dockerfile:30` git clone age, `docker-compose.yml:30` shared_preload_libraries=age |
+| M4 | run_workflow/resume_workflow TimeoutError 미처리 재전파(구조화 반환 계약 위반) | 009 | M | `workflow.py:502-507,534` except TimeoutError: raise (main.py 핸들러 없음→CLI 크래시) |
+| M5 | ParsedDocument 이원 정의(parser_dtos dataclass ↔ schemas Pydantic) | 001 | M | `parser_dtos.py:67` vs `schemas.py:30` |
+| M6 | CI/자동화 파이프라인 부재(.github/workflows 없음) | infra | L | `.github/` 디렉터리 없음 |
+| M7 | index_documents 부분실패 시 손실 청크 복구 신호 부재 | 003 | M | IX-201 스킵 시 부분 커밋, 재적재 훅 없음 |
+| M8 | 리랭커 import-time 모델 로드 실패 graceful fallback 미검증 | 006 | M | CrossEncoder 모듈 로드 시점 의존 |
+
+### 🟡 Minor (정리/개선)
+
+| # | 항목 | FUNC | 공수 |
+|---|---|---|---|
+| m1 | skip 스텁 테스트 6건 정리 | 001·002 | S |
+| m2 | rewrite 이중 예외처리 + error_logs timestamp 공백 | 004·009 | S |
+| m3 | rerank()/evaluate() needs_reretrieval 명시 + reranker.py:55 TODO 정리 | 006·007 | S |
+| m4 | handle_node_errors 전 노드 일관 적용 + evaluation=None 라우팅 명시 | 009 | M |
+| m5 | metadata_filter SQL 안전성 문서화(현행 psycopg 파라미터 바인딩으로 주입 위험 낮음 — 검토/명문화 수준) | 003·005 | S |
+
+### 정정 (감사 과정의 과장 시정)
+- **AGE 제거**: src/ Python 코드는 클린(✅). 단 DB 인프라(db.Dockerfile/docker-compose/.env.example/infra_check.py)는 여전히 AGE 빌드·로드 → M3로 분류.
+- **Dense 인덱스**: HNSW 인덱스 생성 코드 존재(`vector_store.py:62`) ✅ — 누락 아님.
+- **SQL injection**: 파라미터 바인딩 사용으로 실제 위험 낮음 → m5(문서화)로 강등.
+
+---
+
+## 2. Phase 3 — 프로덕션 로드맵 (v1.0 이후)
+
+### 관찰성 (Observability)
+- [high] 구조화 로깅(JSON Lines) 도입 — 현재 text formatter만
+- [high] 요청 단위 trace_id 전파 — thread_id는 HIL 전용, 전 경로 단일 trace 부재
+- [high] 메트릭 수집 — `logger.py`의 log_execution_time 스텁 완성
+- [med] LLM 토큰/비용 추적 — OpenAI usage 미기록
+- [low] LangSmith 트레이싱 연동 — 의존성 선언만 있고 import 0건
+
+### 에러 핸들링·복구
+- [med] `is_retryable` 메타데이터 활성화 — 현재 dead code, 재시도 라우팅에 연결
+- [med] error_logs 무한 증가 가드 — TTL/상한/회전 없이 MemorySaver 누적
+- [med] index_documents 부분실패 dead-letter/재시도 훅(M7)
+- [low] CRAG rewrite_count 재진입 전략 확정(동일 재시도 vs hyde→decompose→stepback 에스컬레이션)
+
+### 성능·부하
+- [high] pgvector HNSW 인덱싱 성능 벤치마크 (#98)
+- [high] 대량 적재 OOM 완화 검증 (#117, KURE-v1 CPU 프로파일)
+- [med] 한국어 형태소 sparse 검색 (#81, pg_bigm/사전 토큰화) — 현재 `to_tsvector('simple')` + GIN 인덱스 없음(매 질의 풀스캔)
+- [med] RRF k 튜닝 벤치마크 (#99)
+- [med] 연결풀 고갈 가드 — getconn 타임아웃 없음(max_size=10)
+- [med] OpenAI 클라이언트 timeout/retry — step_timeout(30s) < API 기본(60s) 불일치
+
+### 배포 인프라
+- [med] DB 스키마 마이그레이션 도구(Alembic 등) — 현재 _ensure_collection 동적 생성만
+- [med] DB 백업·복구·DR 절차
+- [med] Docker 멀티스테이지 빌드 — 프로덕션 이미지에 dev 의존성(pytest) 포함
+- [med] 헬스체크/준비성 프로브 (docker-compose)
+- [low] 이미지 태그 버전 고정
+- [low] v1.1 패키지화 + 로컬 MCP 서버 BYO-corpus (#103)
+
+---
+
+## 3. 기존 이슈와의 연계
+
+이미 추적 중(open): #38(NFR-001), #81(한국어 sparse), #96(NFR-002), #98(인덱싱 벤치), #99(RRF k), #101(온톨로지 6/20), #103(v1.1 패키지), #104(HIL 벤치), #117(OOM), #126(AGE infra_check).
+
+신규 발행 후보(net-new): G2·M1·M2·M4·M5·M6·M7·M8. (M3는 #126 확장 코멘트로 보강)
+저작권(구 G1)은 회계기준원 허가 확보로 제외.


### PR DESCRIPTION
## 개요

v1.0 출시(D-1) 시점의 **코드 실태 기준 설계·감사 문서 세트**를 추가합니다. 기존 `ARCHITECTURE.md`는 Apache AGE / EdgeQuake / GraphRAG를 전제한 초기 설계라 현행 구현(pgvector + BM25 하이브리드)과 어긋나 있었습니다. 이를 superseded 처리하고, 실제 코드(`src/`)·테스트 실측에 기반한 현행 아키텍처 개요, FUNC 인터페이스 명세, 로컬 셋업 가이드, v1.0 전체 감사 보고서를 새로 정리했습니다.

문서 전용 PR이며 소스 코드 변경은 없습니다.

---

## 변경 사항

### 신규 구현

- **`docs/architecture_overview.md`** — 현행 아키텍처 개요(v1.0). pgvector + BM25(tsvector) 하이브리드 검색 기준의 적재/질의 흐름, 핵심 설계 결정 표, 실제 모듈 지도
- **`docs/func_interfaces.md`** — FUNC-001~009 입출력 계약 명세. `schemas.py`/`state.py` 기준 스키마 요약 + 기능별 진입점·에러코드·주의사항
- **`docs/local_dev_setup.md`** — uv 기반 로컬 개발 셋업 가이드(의존성·환경변수·DB 기동·ingest/query 실행·테스트 마커)
- **`docs/v1_audit_report.md`** — v1.0 전체 감사 보고서. 종합 판정, FUNC 상태 요약, 테스트 실측, 갭 분석(릴리즈 게이트/Major/Minor)

### 수정

- **`docs/ARCHITECTURE.md`** — 상태 헤더를 `⚠️ SUPERSEDED`로 변경. AGE 전제의 초기 설계임을 명시하고 현행 문서(`architecture_overview.md`)로 안내. 초기 설계 의도 기록용으로만 보존

---

## 주요 내용

### 감사 종합 판정 — 조건부 병합 가능 (`ready_with_minor_gaps`)

9개 FUNC 코어 로직이 실제 구현되어 있고 단위 테스트 **276 passed**로 회귀가 없습니다. 컴파일/런타임을 차단하는 하드 블로커는 없으며, 병합 전 처리할 릴리즈 게이트는 1건입니다.

| 게이트 | 내용 | 권고 |
|---|---|---|
| 🔴 라이브 E2E 미검증 | 단위/통합 테스트 전부 mock(임베딩·LLM·리랭커). 실 DB·실 LLM 관통 증거 없음. `OPENAI_MODEL` 유효성 미확인 | 병합 직전 1회 라이브 스모크(1개 챕터 ingest → query 1건) |

> 저작권 데이터(과거 #102)는 회계기준원(KASB) 사용 허가 확보로 게이트가 아님.

### 테스트 실측 (2026-06-13)

| 계층 | 결과 | 비고 |
|---|---|---|
| 단위(unit) | 276 passed, 5 skipped | 견고. 단 전부 mock |
| 시스템(system, fast-fail) | 34 passed, 323 deselected | 가짜 데이터 예외/규격 검증 |
| 통합(integration) | 28 failed, 48 passed | 라이브 DB·적재 부재로 benchmark_compliance 전패. NFR-002 정확도 미측정 |

### 문서 정합성 정리

- 초기 설계(`ARCHITECTURE.md`)와 현행 구현의 괴리 해소: AGE/GraphRAG → pgvector + BM25 하이브리드로 대체된 사실을 superseded 마킹으로 명확화
- FUNC별 입출력 계약을 코드 실태 기준으로 단일화하여 후속 개발/리뷰의 기준 문서 제공

---

## 체크리스트

- [x] 문서 전용 변경 — 소스 코드/테스트 영향 없음
- [x] `ARCHITECTURE.md` superseded 안내 및 현행 문서 링크 정합성 확인
- [x] 감사 보고서 테스트 수치를 2026-06-13 실측 기준으로 기재
- [ ] 릴리즈 게이트(라이브 E2E 스모크)는 병합 직전 별도 수행 예정
