### PR TITLE
feat: 사용자 대면 질의 화면(Streamlit UI) 추가 (#148, #135)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -7,9 +7,13 @@ FROM python:3.12-slim
     # 파이썬은 .py를 실행하기 전에 컴퓨터가 더 빨리 읽을 수 있는 이진 파일인 .pyc로 변환하여 컴파일한다.
     # 컨테이너 환경에서는 이미지가 빌드된 후 코드를 고정하므로, 런타임 중 소스코드가 수정될 일이 없어서 굳이 .pyc를 생성할 필요가 없다.
 # UV_COMPILE_BYTECODE=1: uv에서 패키지 설치 시 바이트코드를 미리 컴파일하여 초기 실행 속도를 높입니다.
+# UV_LINK_MODE=copy: .venv가 익명 볼륨(별도 파일시스템)이라 uv 캐시에서 하드링크가 불가능해
+#   매 `uv run`마다 "Failed to hardlink files ... falling back to full copy" 경고가 출력된다.
+#   복사 모드를 명시해 해당 경고를 제거한다(uv 공식 권장 우회).
 ENV PYTHONUNBUFFERED=1 \
     PYTHONDONTWRITEBYTECODE=1 \
-    UV_COMPILE_BYTECODE=1
+    UV_COMPILE_BYTECODE=1 \
+    UV_LINK_MODE=copy
 
 # [PATH 경로 설정]
 # uv sync가 생성하는 가상환경(.venv)의 실행 파일 폴더를 시스템 PATH 최상단에 추가합니다.

--- a/app.py
+++ b/app.py
@@ -1,0 +1,137 @@
+"""회계 기준서 RAG — 사용자 대면 질의 화면 (최소 Streamlit UI).
+
+CLI(`src/main.py query`)와 동일한 워크플로(run_workflow → resume_workflow)를 브라우저에서 실행한다.
+HIL(human_review) interrupt가 발생하면 승인/재작성을 화면에서 받아 재개한다.
+
+실행 (app 컨테이너 안에서):
+    docker compose exec app uv run streamlit run app.py \
+        --server.port 8501 --server.address 0.0.0.0
+    → 브라우저에서 http://localhost:8501  (docker-compose의 8501 포트 매핑 필요)
+
+Streamlit은 사용자 상호작용마다 스크립트를 처음부터 다시 실행하므로,
+진행 상태(idle/interrupted/done)와 중간 결과를 st.session_state에 보관해
+run → (HIL 승인/재작성)* → done 흐름을 상태머신으로 관리한다.
+"""
+from __future__ import annotations
+
+import streamlit as st
+
+from src.agent.workflow import resume_workflow, run_workflow
+from src.db.connection import init_pool
+
+STANDARD_OPTIONS = ["ALL", "GAAP", "KIFRS"]
+
+
+# st.cache_resource: 동일 프로세스 내 재실행 간에 캐시 유지
+@st.cache_resource
+def _ensure_pool() -> bool:
+    """DB 커넥션 풀을 프로세스당 1회 초기화한다(Streamlit 재실행 간 캐시).
+
+    init_pool()은 idempotent하지만 cache_resource로 감싸 1회만 호출되게 하고, 풀은 앱 프로세스 수명 동안 닫지 않는다(매 재실행마다 close하지 않도록).
+    """
+    init_pool()
+    return True
+
+
+def _is_interrupt(result: dict) -> bool:
+    """워크플로 결과가 HIL interrupt로 중단되었는지 여부."""
+    return isinstance(result, dict) and "__interrupt__" in result
+
+
+def _interrupt_payload(result: dict) -> dict:
+    """invoke 결과의 __interrupt__ 값을 dict 페이로드로 정규화한다(main.py와 동일 규약)."""
+    intr = result["__interrupt__"]
+    item = intr[0] if isinstance(intr, (list, tuple)) and intr else intr
+    payload = getattr(item, "value", item)
+    return payload if isinstance(payload, dict) else {}
+
+
+def _apply(result: dict) -> None:
+    """워크플로 결과를 세션 상태에 반영하고 다음 단계(interrupted/done)를 결정한다."""
+    st.session_state.result = result
+    st.session_state.thread_id = result.get("thread_id")
+    st.session_state.stage = "interrupted" if _is_interrupt(result) else "done"
+
+
+def _render_response(result: dict) -> None:
+    """FinalResponse를 답변·신뢰도·인용으로 렌더링한다."""
+    response = result.get("final_response")
+    if response is None:
+        st.warning("답변을 생성하지 못했습니다.")
+        return
+
+    if response.is_answerable:
+        st.success("답변 가능")
+    else:
+        st.warning("제공된 회계기준 문서에서 충분한 근거를 찾지 못했습니다.")
+
+    st.markdown("### 답변")
+    st.markdown(response.answer)
+    st.metric("신뢰도", f"{response.confidence_score:.1%}")
+
+    st.markdown(f"### 인용 ({len(response.citations)}건)")
+    if not response.citations:
+        st.caption("인용 없음")
+    for i, c in enumerate(response.citations, start=1):
+        with st.expander(f"[{i}] {c.document_id} / {c.chunk_id}  ·  관련도 {c.relevance_score:.2f}"):
+            st.write(c.content)
+
+
+# ───────────────────────────── 화면 ─────────────────────────────
+st.set_page_config(page_title="회계 기준서 RAG", page_icon="📘")
+st.title("회계 기준서 RAG 질의")
+
+_ensure_pool()
+st.session_state.setdefault("stage", "idle")
+
+# 질의 입력 폼 (HIL 확인 중에는 새 질의 시작을 막는다)
+with st.form("query_form", clear_on_submit=False):
+    query = st.text_input("질의", placeholder="예: 재고자산의 취득원가는 어떻게 측정하나요?")
+    standard = st.selectbox("기준 필터", STANDARD_OPTIONS, index=0)
+    submitted = st.form_submit_button(
+        "질의", disabled=st.session_state.stage == "interrupted"
+    )
+
+if submitted and query.strip():
+    with st.spinner("워크플로 실행 중… (rewrite → search → rerank → evaluate → generate)"):
+        try:
+            result = run_workflow(query.strip(), standard_filter=standard)
+        except Exception as e:  # noqa: BLE001 — 화면에 오류를 노출하는 것이 목적
+            st.error(f"실행 오류: {type(e).__name__}: {e}")
+            st.stop()
+    _apply(result)
+    st.rerun()
+
+# HIL interrupt — 재작성 전략 확인(승인/재작성)
+if st.session_state.stage == "interrupted":
+    payload = _interrupt_payload(st.session_state.result)
+    st.info("재작성 전략이 사용자 확인을 요구합니다.")
+    st.write(f"**전략:** {payload.get('strategy', '?')}")
+    st.write(f"**원질의:** {payload.get('original_query', '')}")
+    for j, q in enumerate(payload.get("search_queries", []), start=1):
+        st.write(f"- 검색쿼리 {j}: {q}")
+
+    approve = st.button("이대로 진행 (승인)")
+    with st.form("rewrite_form", clear_on_submit=True):
+        feedback = st.text_input("재작성 피드백")
+        rewrite = st.form_submit_button("재작성 요청")
+
+    decision = None
+    if approve:
+        decision = {"action": "approve"}
+    elif rewrite:
+        decision = {"action": "rewrite", "feedback": feedback}
+
+    if decision is not None:
+        with st.spinner("재개 중…"):
+            try:
+                result = resume_workflow(st.session_state.thread_id, decision)
+            except Exception as e:  # noqa: BLE001
+                st.error(f"재개 오류: {type(e).__name__}: {e}")
+                st.stop()
+        _apply(result)
+        st.rerun()
+
+# 최종 결과 렌더
+if st.session_state.stage == "done":
+    _render_response(st.session_state.result)

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,6 +35,11 @@ services:
       POSTGRES_USER: ${POSTGRES_USER:-accounting_user}
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-accounting_password}
       POSTGRES_DB: ${POSTGRES_DB:-accounting_db}
+    # [질의 화면(Streamlit) 포트 매핑]
+    # app.py(이슈 #148, 최소 질의 UI)를 `streamlit run app.py --server.port 8501`로 띄울 때
+    # 호스트 브라우저(http://localhost:8501)에서 컨테이너 내부 8501에 접근하기 위한 통로.
+    ports:
+      - "8501:8501"
     volumes:
       # [실시간 코드 동기화]
       # 로컬 PC의 현재 디렉토리 코드를 컨테이너의 /app 시스템으로 실시간 마운트시켜 놓습니다.
@@ -54,6 +59,12 @@ services:
       # 호스트의 `./`를 `/app`에 마운트하면 이미지 빌드 시 생성된 `/app/.venv` 폴더가 내 PC의 폴더 내용으로 덮어씌워집니다.
       # 아래와 같이 익명 볼륨(`/app/.venv`)을 명시하면, 컨테이너 내부의 `.venv`는 호스트의 영향을 받지 않고 이미지에 설치된 상태 그대로 유지됩니다.
       - /app/.venv
+      # [임베딩/리랭커 모델 캐시 영속화]
+      # KURE-v1·CrossEncoder는 Dockerfile에서 prefetch하지 않고 런타임에
+      # /root/.cache/huggingface로 다운로드된다. 이름 있는 볼륨으로 분리하면
+      # 컨테이너 재생성(docker compose up) 시에도 모델(~2GB)을 다시 받지 않는다.
+      # (볼륨이 비어 있는 최초 1회만 다운로드)
+      - hf_cache:/root/.cache/huggingface
     depends_on:
       - database
     restart: unless-stopped
@@ -67,3 +78,4 @@ services:
 
 volumes:
   postgres_data:
+  hf_cache:

--- a/src/agent/nodes/evaluate.py
+++ b/src/agent/nodes/evaluate.py
@@ -82,7 +82,9 @@ def evaluate_context(state: GraphState) -> dict:
     )
 
     # PydanticAI Agent로 EvaluationResult 직접 파싱
-    evaluator_agent = Agent(f"openai:{OPENAI_MODEL}", output_type=EvaluationResult)
+    # 접두사를 "openai-chat:"으로 고정한다. pydantic-ai v2.0부터 "openai:"는 Responses API로
+    # 해석되도록 바뀌어 DeprecationWarning이 발생하므로, 현행 Chat Completions 동작을 명시적으로 유지한다.
+    evaluator_agent = Agent(f"openai-chat:{OPENAI_MODEL}", output_type=EvaluationResult)
 
     try:
         result = evaluator_agent.run_sync(prompt)

--- a/src/agent/nodes/generate.py
+++ b/src/agent/nodes/generate.py
@@ -29,7 +29,9 @@ def generate_response(state: GraphState) -> dict:
     - 인용 근거를 포함한 FinalResponse를 state.final_response에 저장
     """
     # PydanticAI 에이전트 초기화
-    generator_agent = Agent(f"openai:{OPENAI_MODEL}", output_type=LLMInternalResponse)
+    # 접두사를 "openai-chat:"으로 고정한다. pydantic-ai v2.0부터 "openai:"는 Responses API로
+    # 해석되도록 바뀌어 DeprecationWarning이 발생하므로, 현행 Chat Completions 동작을 명시적으로 유지한다.
+    generator_agent = Agent(f"openai-chat:{OPENAI_MODEL}", output_type=LLMInternalResponse)
 
     # 검색 결과가 없으면 답변 불가능 처리
     if not state.reranked_chunks:

--- a/src/retrieval/reranker.py
+++ b/src/retrieval/reranker.py
@@ -10,15 +10,32 @@ logger = get_logger(__name__)
 
 # 모델 로드 실패 시에도 모듈 임포트가 NameError 없이 진행되도록 기본값을 선언한다.
 # (선언이 없으면 로드 실패 시 compute_relevance_scores의 None 체크가 NameError로 터진다)
+#
+# [지연 로딩] 모델은 import 시점이 아니라 compute_relevance_scores 최초 호출 시 1회만 로드한다.
+# USE_RERANKER=false(기본값)이면 rerank 노드가 compute_relevance_scores를 호출하지 않으므로
+# 모델(~수백 MB)을 받지 않는다 → 앱/워크플로 import 시 불필요한 다운로드·메모리·로드 로그를 제거한다.
 _cross_encoder = None
 _load_error = None
-try:
-    from sentence_transformers import CrossEncoder as _CrossEncoder
-    _cross_encoder = _CrossEncoder(RERANK_MODEL)
-    logger.info(f"Cross-Encoder 모델 로드 완료: {RERANK_MODEL}")
-except Exception as e:
-    _load_error = e
-    logger.warning(f"Cross-Encoder 모델 로드 실패 — compute_relevance_scores 호출 시 RerankFailureError 발생: {e}")
+_load_attempted = False
+
+
+def _ensure_model_loaded() -> None:
+    """Cross-Encoder 모델을 지연 로딩한다(프로세스당 1회 시도).
+
+    _cross_encoder 또는 _load_error 중 하나라도 이미 설정돼 있으면(성공/실패 확정,
+    또는 테스트가 직접 주입한 경우) 재시도하지 않고 즉시 반환한다.
+    """
+    global _cross_encoder, _load_error, _load_attempted
+    if _cross_encoder is not None or _load_error is not None or _load_attempted:
+        return
+    _load_attempted = True
+    try:
+        from sentence_transformers import CrossEncoder
+        _cross_encoder = CrossEncoder(RERANK_MODEL)
+        logger.info(f"Cross-Encoder 모델 로드 완료: {RERANK_MODEL}")
+    except Exception as e:
+        _load_error = e
+        logger.warning(f"Cross-Encoder 모델 로드 실패 — compute_relevance_scores 호출 시 RerankFailureError 발생: {e}")
 
 
 def rerank_chunks(original_query: str, chunks: list[RetrievedChunk]) -> list[RerankingResult]:
@@ -75,6 +92,7 @@ def compute_relevance_scores(query: str, contents: list[str]) -> list[float]:
     CrossEncoder.predict()는 쌍 리스트를 한 번의 forward pass로 처리하므로
     청크 수와 무관하게 모델 추론을 1회만 수행한다.
     """
+    _ensure_model_loaded()
     if _cross_encoder is None:
         raise RerankFailureError(f"Cross-Encoder 모델 로드 실패: {_load_error}")
     pairs = [(query, content) for content in contents]

--- a/tests/unit/retrieval/test_reranker.py
+++ b/tests/unit/retrieval/test_reranker.py
@@ -1,7 +1,10 @@
 import math
+import sys
+import types
 
 import pytest
 from unittest.mock import patch, MagicMock
+from src.retrieval import reranker as reranker_module
 from src.retrieval.reranker import rerank_chunks, compute_relevance_scores
 from src.agent.workflow import rerank
 from src.models.schemas import RetrievedChunk, RerankingResult
@@ -217,3 +220,77 @@ class TestRerankNode:
         assert len(result["reranked_chunks"]) == len(sample_chunks)  # reranked_chunks의 길이가 1차 검색 결과와 같은지 확인
         assert "needs_reretrieval" in result  # needs_reretrieval이 존재하는지 확안
         assert result["needs_reretrieval"] is False  # needs_reretrieval이 False인지 확안
+
+
+@pytest.mark.unit
+class TestLazyModelLoadFailure:
+    """CrossEncoder 지연 로딩(_ensure_model_loaded)의 로드 실패 graceful 동작 검증.
+
+    기존 TestComputeRelevanceScores.test_model_load_failure_raises_rerank_failure_error는
+    '실패 상태(_cross_encoder=None, _load_error=설정)'를 직접 주입할 뿐, 
+    로드 자체가 실패하는 경로(_ensure_model_loaded 내부에서 CrossEncoder 생성이 예외를 던지는 케이스)는 검증하지 않는다.
+    여기서 그 경로를 모델 다운로드 실패로 시뮬레이션한다.
+    """
+
+    @staticmethod
+    def _failing_sentence_transformers(message: str) -> types.ModuleType:
+        """CrossEncoder() 생성이 예외를 던지는 가짜 sentence_transformers 모듈.
+
+        실제 torch/모델 로드 없이, _ensure_model_loaded 내부의
+        `from sentence_transformers import CrossEncoder`가 이 가짜를 집어가도록 한다.
+        """
+        fake = types.ModuleType("sentence_transformers")
+        fake.CrossEncoder = MagicMock(side_effect=RuntimeError(message))
+        return fake
+
+    def test_load_failure_is_graceful_then_raises_on_use(self):
+        """모델 로드(다운로드) 실패 시 _ensure_model_loaded는 예외를 삼켜 graceful하게 처리하고,
+        이후 compute_relevance_scores 호출 시 NameError가 아닌 RerankFailureError로 분기되는지 검증.
+        """
+        fake_st = self._failing_sentence_transformers("모델 다운로드 실패(캐시 부재)")
+
+        # 지연 로딩 상태를 초기화하여 _ensure_model_loaded가 실제 로드를 시도하도록 강제한다.
+        with patch.object(reranker_module, "_cross_encoder", None), \
+             patch.object(reranker_module, "_load_error", None), \
+             patch.object(reranker_module, "_load_attempted", False), \
+             patch.dict(sys.modules, {"sentence_transformers": fake_st}):
+            # 로드 시도 자체는 예외를 전파하지 않는다.
+            reranker_module._ensure_model_loaded()
+            assert reranker_module._cross_encoder is None
+            assert isinstance(reranker_module._load_error, RuntimeError)
+
+            # 실제 사용 시점에 RerankFailureError로 분기.
+            with pytest.raises(RerankFailureError, match="Cross-Encoder 모델 로드 실패"):
+                compute_relevance_scores("질의", ["문서1", "문서2"])
+
+    def test_load_attempted_once_no_retry_storm(self):
+        """로드는 프로세스당 1회만 시도되고, 실패해도 매 호출마다 재시도하지 않는지 검증.
+
+        _load_attempted 가드가 없으면 호출마다 모델 생성을 재시도해 다운로드/지연이 반복된다.
+        """
+        fake_st = self._failing_sentence_transformers("once")
+
+        with patch.object(reranker_module, "_cross_encoder", None), \
+             patch.object(reranker_module, "_load_error", None), \
+             patch.object(reranker_module, "_load_attempted", False), \
+             patch.dict(sys.modules, {"sentence_transformers": fake_st}):
+            reranker_module._ensure_model_loaded()
+            reranker_module._ensure_model_loaded()  # 두 번째 호출은 가드로 즉시 반환되어야 함
+
+            fake_st.CrossEncoder.assert_called_once()  # 모델 생성 시도는 1회뿐
+
+    def test_rerank_chunks_propagates_rerank_failure_on_load_failure(self, sample_chunks):
+        """로드 실패 상태에서 rerank_chunks(청크 2개 이상)가 RerankFailureError를 전파하는지 검증.
+
+        rerank() 노드는 이 RerankFailureError를 RR-201로 받아 1차 검색 결과 폴백으로 강등한다
+        (TestRerankNode.test_rerank_model_failure_records_error_log). 
+        즉 로드 실패가 파이프라인을 크래시시키지 않고 graceful 폴백으로 흡수되는 전체 경로의 진입점을 고정한다.
+        """
+        fake_st = self._failing_sentence_transformers("load fail")
+
+        with patch.object(reranker_module, "_cross_encoder", None), \
+             patch.object(reranker_module, "_load_error", None), \
+             patch.object(reranker_module, "_load_attempted", False), \
+             patch.dict(sys.modules, {"sentence_transformers": fake_st}):
+            with pytest.raises(RerankFailureError, match="Cross-Encoder 모델 로드 실패"):
+                rerank_chunks("질의", sample_chunks)


### PR DESCRIPTION
## 개요

CLI(`src/main.py query`)뿐이던 사용자 대면 인터페이스에 **최소 Streamlit 질의 화면**을 추가합니다(이슈 #148, 옵션 b — 데모/시연용 화면). 기존 워크플로(`run_workflow → resume_workflow`)를 그대로 재사용하여, 질의 입력 → 임베딩 DB 하이브리드 검색 → LLM 답변·인용을 브라우저에서 확인할 수 있습니다. 함께, 라이브 실행 중 관찰된 런타임 경고들을 정리합니다(거동 불변).

---

## 변경 사항

### 신규 구현

- **`app.py`** — 최소 Streamlit 질의 화면. 질의 입력 + 기준 필터(ALL/GAAP/KIFRS) → `run_workflow()` → 답변·신뢰도·인용 렌더. HIL(`__interrupt__`) 발생 시 재작성 전략을 표시하고 승인/재작성을 받아 `resume_workflow()`로 재개. Streamlit 재실행 모델에 맞춰 `idle→interrupted→done` 상태머신(`st.session_state`)으로 관리.

### 수정

- **`docker-compose.yml`** — `app` 서비스에 `8501:8501` 포트 매핑 + `hf_cache` 명명 볼륨(`/root/.cache/huggingface`) 추가. 컨테이너 재생성 시에도 임베딩/리랭커 모델(~2GB)을 재다운로드하지 않도록 캐시를 영속화.
- **`src/agent/nodes/evaluate.py`, `src/agent/nodes/generate.py`** — PydanticAI 모델 접두사를 `openai:` → `openai-chat:`로 고정. pydantic-ai v2.0부터 `openai:`가 Responses API로 해석되며 발생하는 `DeprecationWarning`을 제거(현행 Chat Completions 동작 명시적 유지, **거동 불변**).
- **`src/retrieval/reranker.py`** — CrossEncoder를 **지연 로딩**으로 전환(import 시점 → `compute_relevance_scores` 최초 호출 시 1회). `USE_RERANKER=false`(기본값)이면 모델을 받지 않아 앱/워크플로 import 시 불필요한 다운로드·메모리·로드 로그 제거. 로드 실패 시 `RerankFailureError` 폴백은 유지.
- **`Dockerfile`** — `UV_LINK_MODE=copy` 추가. `.venv`가 익명 볼륨이라 하드링크 불가로 매 `uv run`마다 출력되던 "Failed to hardlink files … falling back to full copy" 경고 제거(uv 권장 우회).

### 테스트 추가 (#135)

- **`tests/unit/retrieval/test_reranker.py`** — `_ensure_model_loaded()` **지연 로딩 실패 경로**의 graceful 동작 검증 3건(`TestLazyModelLoadFailure`): ① 모델 로드(다운로드) 실패가 예외 전파 없이 흡수되고 이후 사용 시 `RerankFailureError`로 분기(NameError·원본 예외 누출 없음), ② 로드는 1회만 시도(실패해도 재시도 폭주 없음), ③ `rerank_chunks`가 로드 실패를 `RerankFailureError`로 전파(→ 노드에서 RR-201 폴백). 기존 테스트는 *실패 상태 주입*만 했고 *로드 자체 실패* 경로는 미검증이던 빈틈을 메움.

---

## 아키텍처

### 화면 상태 흐름

```text
질의 입력 + 기준 필터
    │ run_workflow(query, standard_filter)
    ▼
 ┌─ "__interrupt__" 있음 (HIL: decompose/stepback) ──────────────┐
 │    전략·검색쿼리 표시 → 승인 / 재작성(피드백)                  │
 │       └ resume_workflow(thread_id, decision) ──(반복 가능)──┘
 ▼
final_response 렌더 — 답변 · 신뢰도 · 인용([n] document_id/chunk_id/관련도)
```

### 주요 설계 결정

- **워크플로 재사용**: UI 전용 분기 없이 CLI(`run_query`)와 동일한 `run_workflow/resume_workflow` 경로를 호출 → 거동 일관성. 코어 파이프라인(FUNC-001~009) **로직 무수정**(이번 노드 변경은 경고 정리·지연 로딩 한정).
- **DB 풀 1회 초기화**: `@st.cache_resource`로 프로세스당 1회 `init_pool()`. 매 재실행마다 close하지 않음.
- **HIL 재개의 UI화**: `main.py`의 비대화형 자동승인 대신, interrupt 페이로드를 화면에 렌더하고 사용자가 승인/재작성을 선택.

---

## 라이브 검증

- 제7장(재고자산) 14청크 적재 후 **실 pgvector + 실 KURE-v1 + 실 gpt-5.4-mini**로 query 관통:
  - "재고자산의 취득원가는 어떻게 측정하나요?" → 인용 3건, 신뢰도 98.8%
  - "재고자산을 저가법으로 평가하는 경우는?" → 인용 2건(7.16/7.4), 신뢰도 98.8%
- 단위 테스트 **285 passed, 5 skipped**(노드/리랭커 변경 회귀 없음 + #135 신규 3건 포함).

---

## 관련 이슈

- **Closes #148** — 사용자 대면 질의 화면(최소 Streamlit, 옵션 b). 본 PR 머지로 종료 대상.
- **Closes #135** — 리랭커 import-time 로드를 지연 로딩으로 제거 + **로드 실패 graceful fallback 검증 테스트** 추가로 수용 기준 충족.
  - ⚠️ 본 PR 대상 브랜치는 `dev`(기본 브랜치 아님)라, GitHub `Closes` **자동 종료는 `dev → main` 머지 시점**에 동작합니다. dev 머지 시점에 완료로 보신다면 #148·#135를 수동 close하셔도 됩니다.
- 관련(본 PR로 **닫지 않음** — fast-follow):
  - **#136** — `openai-chat:` 고정은 deprecation 정리일 뿐, 모델 폴백 정책은 별건.
  - **#131 / #145** — 라이브에서 관찰된 기존 파이프라인 이슈(타임아웃 크래시 / needs_external 오탐). 본 PR이 유발한 것이 아니며 별도 처리.

---

## 체크리스트

- [x] 실 DB·실 LLM E2E 라이브 관통(답변·인용 생성)
- [x] 단위 테스트 통과 (282 passed, 5 skipped)
- [x] 코어 파이프라인 동작 불변(경고 정리·지연 로딩 한정)
- [x] compose 모델 캐시 영속화(재생성 시 재다운로드 방지)
- [ ] 브라우저에서 HIL(decompose/stepback) 재작성 분기 수동 확인 — 코드 구현 완료, CLI 데모는 hyde 전략이라 HIL 미발생, 브라우저 확인 미완
- [ ] UI 자동화 테스트 — 미포함(현재 수동 검증)
