### PR TITLE
fix: evaluate needs_external 오탐 차단 — 부정 문맥 외부참조 제외 (#145)

### DIFF
--- a/src/agent/nodes/evaluate.py
+++ b/src/agent/nodes/evaluate.py
@@ -17,6 +17,7 @@ from src.utils.logger import get_logger
 
 logger = get_logger(__name__)
 
+# !TODO: 기준서 참조 신호에 대해 더 정교한 방식이 필요함
 # 외부 기준서 참조 지시를 나타내는 신호 문구.
 # reasoning에 다음 중 하나라도 포함되면 standard_filter 값과 무관하게 외부 참조로 판단한다.
 _EXTERNAL_REFERENCE_PHRASES: tuple[str, ...] = (
@@ -29,6 +30,19 @@ _EXTERNAL_REFERENCE_PHRASES: tuple[str, ...] = (
     "외부 기준서",
     "준용한다",
 )
+
+# 외부 참조 문구가 부정 문맥("… 필요하지 않습니다")에서 등장하면 외부 참조로 보지 않기 위한
+# 부정 종결 마커. 외부 참조 문구와 같은 문장에 이 마커가 있으면 그 신호는 무시한다.
+# 단순 substring 매칭이 "외부 기준서 … 필요하지 않습니다"를 외부 참조로 오탐해 needs_external을 강제 True로 만들고 CRAG 루프를 3배 공회전 방지
+_NEGATION_MARKERS: tuple[str, ...] = (
+    "않",       # …하지 않다 / 않습니다 / 않으며
+    "없",       # 필요 없다 / 없습니다
+    "불필요",
+    "아니",     # …가 아니라 …
+)
+
+# 부정 판정을 문장 단위로 한정해, 다른 문장의 부정이 외부 참조 신호를 잘못 무력화하지 않도록 한다.
+_SENTENCE_SPLIT = re.compile(r"[.!?\n]+")
 
 # NOTE:K-GAAP 같은 경우는 제 #### 호와 같은 형태가 아니라 제 ## 장인 것으로 알고 있음
 # 조항 번호 패턴: K-IFRS/K-GAAP 기준서 번호, 3자리 이상 호수, 조항 번호
@@ -180,16 +194,42 @@ def check_relevance(chunk: RerankingResult, query: str) -> bool:
     return chunk.rerank_score >= RERANK_THRESHOLD and len(chunk.chunk.content.strip()) > 0
 
 
+def _is_negated(sentence: str) -> bool:
+    """문장에 부정 종결 마커가 포함되어 있으면 True(외부 참조 신호를 무시해야 하는 문맥)."""
+    return any(marker in sentence for marker in _NEGATION_MARKERS)
+
+
+def _signals_external_reference(reasoning: str, standard_filter: str | None = None) -> bool:
+    """reasoning을 문장 단위로 보고, 부정 문맥이 아닌 외부 참조 신호가 하나라도 있으면 True.
+
+    - _EXTERNAL_REFERENCE_PHRASES(명시적 외부 참조 지시)는 standard_filter와 무관하게 신호로 본다.
+    - standard_filter가 단일 기준서(GAAP/KIFRS)면 같은 문장에 반대 기준서가 등장해도 신호로 본다.
+    - 외부 참조 문구가 부정 문맥("… 필요하지 않습니다")에 있는 문장은 신호에서 제외한다.
+    """
+    for sentence in _SENTENCE_SPLIT.split(reasoning):
+        if _is_negated(sentence):
+            continue
+        if any(phrase in sentence for phrase in _EXTERNAL_REFERENCE_PHRASES):
+            return True
+        if standard_filter == "GAAP" and "K-IFRS" in sentence:
+            return True
+        if standard_filter == "KIFRS" and "K-GAAP" in sentence:
+            return True
+    return False
+
+
 def check_external_reference(evaluation: EvaluationResult, standard_filter: str) -> bool:
     """
     평가 결과의 reasoning에서 외부 기준서 참조 필요 여부를 판단한다.
 
     판단 규칙:
-        1. _EXTERNAL_REFERENCE_PHRASES 중 하나라도 reasoning에 포함되면 True
+        1. _EXTERNAL_REFERENCE_PHRASES 중 하나가 (부정 문맥이 아닌) 문장에 포함되면 True
            (명시적 외부 참조 지시는 standard_filter와 무관하게 외부 참조로 본다)
         2. standard_filter가 "ALL"이면 IFRS·GAAP 키워드 단독으로는 True를 반환하지 않음
            (양쪽 기준서가 모두 검색 대상이므로 단순 키워드 등장은 외부 참조가 아님)
-        3. standard_filter가 단일 기준서(GAAP/KIFRS)일 때 반대 기준서가 reasoning에 등장하면 True
+        3. standard_filter가 단일 기준서(GAAP/KIFRS)일 때 반대 기준서가 (부정 문맥이 아닌)
+           문장에 등장하면 True
+        4. 외부 참조 문구가 부정 문맥("… 필요하지 않습니다")에서 등장하면 외부 참조로 보지 않는다.
 
     Args:
         evaluation: LLM이 산출한 평가 결과
@@ -198,20 +238,7 @@ def check_external_reference(evaluation: EvaluationResult, standard_filter: str)
     Returns:
         bool: 외부 참조 필요 여부
     """
-    reasoning = evaluation.reasoning
-
-    if any(phrase in reasoning for phrase in _EXTERNAL_REFERENCE_PHRASES):
-        return True
-
-    if standard_filter == "ALL":
-        return False
-
-    if standard_filter == "GAAP" and "K-IFRS" in reasoning:
-        return True
-    if standard_filter == "KIFRS" and "K-GAAP" in reasoning:
-        return True
-
-    return False
+    return _signals_external_reference(evaluation.reasoning, standard_filter)
 
 
 def validate_verdict(eval_result: EvaluationResult) -> None:
@@ -228,10 +255,10 @@ def validate_verdict(eval_result: EvaluationResult) -> None:
         )
     # needs_external=True이고 is_relevant=True이면 외부 참조가 필요하다.
     if eval_result.needs_external and eval_result.is_relevant:
-        # 외부 참조 지시어가 있는지 확인
-        has_external_signal = any(
-            phrase in eval_result.reasoning for phrase in _EXTERNAL_REFERENCE_PHRASES
-        )
+        # 외부 참조 지시어가 있는지 확인.
+        # check_external_reference와 동일한 부정-인지 판정을 공유해, 부정 문맥("… 필요하지 않습니다")의
+        # 외부 참조 문구를 신호로 오인하던 문제를 일관되게 차단한다.
+        has_external_signal = _signals_external_reference(eval_result.reasoning)
         # 외부 참조 지시어가 없으면 불일치
         if not has_external_signal:
             raise InconsistentVerdictError(

--- a/tests/unit/agent/test_evaluate.py
+++ b/tests/unit/agent/test_evaluate.py
@@ -120,6 +120,24 @@ class TestCheckExternalReference:
         )
         assert check_external_reference(evaluation, "GAAP") is True # 기준서 필터로 인해 외부 참조로 판단
 
+    def test_negated_external_phrase_returns_false(self):
+        """외부 참조 문구가 부정 문맥("… 필요하지 않습니다")이면 외부 참조로 보지 않는다"""
+        evaluation = EvaluationResult(
+            is_relevant=True, needs_external=False, confidence=0.96,
+            reasoning="검색된 청크로 충분하며 외부 기준서 추가 검색이 필요하지 않습니다."
+        )
+        assert check_external_reference(evaluation, "ALL") is False
+        assert check_external_reference(evaluation, "GAAP") is False
+        assert check_external_reference(evaluation, "KIFRS") is False
+
+    def test_negated_sentence_does_not_suppress_positive_sentence(self):
+        """부정 문장이 있어도, 다른 문장의 (부정 아닌) 외부 참조 지시는 살아남아 True"""
+        evaluation = EvaluationResult(
+            is_relevant=False, needs_external=False, confidence=0.5,
+            reasoning="청크 본문만으로는 부족하지 않습니다. 다만 해당 항목은 타 기준서 준용이 필요합니다."
+        )
+        assert check_external_reference(evaluation, "ALL") is True
+
 
 @pytest.mark.unit
 class TestEvaluateContext:
@@ -215,6 +233,35 @@ class TestEvaluateContext:
         eval_result = result["evaluation"]
         assert eval_result.needs_external is False  # 추론 불필요, ALL 필터 적용
         assert eval_result.is_relevant is True  # LLM 응답 유지
+
+    def test_negated_external_reasoning_does_not_override(self):
+        """LLM이 needs_external=False + 부정 문맥 reasoning을 반환하면,
+        check_external_reference가 오버라이드하지 않아 needs_external=False가 보존된다.
+        substring 오탐으로 CRAG 루프가 MAX_REWRITE_COUNT까지 3배 공회전하던 회귀 방지
+        """
+        llm_eval = EvaluationResult(
+            is_relevant=True,
+            needs_external=False,
+            confidence=0.96,
+            reasoning="청크에 충분한 근거가 있어 외부 기준서 추가 검색이 필요하지 않습니다."
+        )
+        state = GraphState(
+            original_query="재고자산의 취득원가는 어떻게 측정하나요?",
+            standard_filter="ALL",
+            reranked_chunks=[
+                RerankingResult(
+                    chunk=RetrievedChunk(chunk_id="c1", document_id="D1", content="취득원가 측정...", score=0.9, metadata={}),
+                    rerank_score=0.95,
+                ),
+            ],
+        )
+        with _mock_evaluator_agent(evaluation=llm_eval):
+            result = evaluate_context(state)
+
+        eval_result = result["evaluation"]
+        assert eval_result.needs_external is False  # 부정 문맥 → 오버라이드 안 함
+        assert eval_result.is_relevant is True      # LLM 응답 유지
+        assert "error_logs" not in result           # 일관성 위반 없음
 
     def test_llm_exception_propagates(self):
         """
@@ -433,6 +480,15 @@ class TestValidateVerdict:
             reasoning="관련 없는 내용입니다."
         )
         validate_verdict(eval_result)   # 예외 없이 통과해야 함
+
+    def test_needs_external_with_negated_phrase_raises_error(self):
+        """[#145] needs_external=True인데 외부 참조 문구가 부정 문맥이면 신호로 보지 않아 불일치"""
+        eval_result = EvaluationResult(
+            is_relevant=True, needs_external=True, confidence=0.8,
+            reasoning="외부 기준서 추가 검색은 필요하지 않습니다."   # 부정 문맥 → 외부 참조 신호 아님
+        )
+        with pytest.raises(InconsistentVerdictError):
+            validate_verdict(eval_result)
 
 
 @pytest.mark.unit


### PR DESCRIPTION
## 개요

`evaluate` 노드가 검색 맥락이 충분한데도 `needs_external=True`로 오판해 CRAG 루프가 `MAX_REWRITE_COUNT(3)`까지 공회전하던 문제를 해결합니다. 라이브 스모크(#137 §4)에서 노출된 결함으로, 최종 답변 정확성에는 영향이 없으나 쿼리당 검색·LLM 호출이 약 3배로 늘어 비용·지연에 직결됩니다.

Closes #145

---

## 원인

`check_external_reference`가 외부 참조 신호 문구(`_EXTERNAL_REFERENCE_PHRASES`, 예: `"외부 기준서"`)를 **부정 문맥을 무시한 단순 substring 매칭**으로 검사했습니다. 그 결과 LLM이 `reasoning`에 *"… 외부 기준서 추가 검색이 **필요하지 않습니다**"* 라고 써도 `"외부 기준서"`가 매칭되어 `needs_external`을 강제 `True`로 오버라이드했습니다. `validate_verdict`의 `has_external_signal`도 동일 substring을 사용해 일관성 검증마저 오통과시켜 결함을 가렸습니다.

---

## 변경 사항

### 수정

- **`src/agent/nodes/evaluate.py`**
  - `_signals_external_reference()` 헬퍼 도입 — `reasoning`을 문장 단위로 분리하고, 외부 참조 문구가 **부정 종결 마커(`않`/`없`/`불필요`/`아니`)와 같은 문장**에 있으면 신호에서 제외
  - `check_external_reference` / `validate_verdict`가 동일 판정을 공유하도록 통일 (두 함수가 어긋나며 버그를 가리던 문제 해소)
  - 다문장일 때 부정 아닌 문장의 외부 참조 지시는 그대로 보존

### 테스트

- **`tests/unit/agent/test_evaluate.py`** — 회귀 4건 추가
  - 부정 문맥 외부 참조 문구 → `False`
  - 다문장 중 긍정 문장 보존 → `True`
  - `validate_verdict` 부정-인지 일관성
  - `evaluate_context` 오버라이드 미발동 (#145 핵심 회귀)

---

## 처리 흐름 (수정 후)

```text
reasoning
  └─ 문장 분리 (. ! ? \n)
       └─ 각 문장: 부정 마커 포함? ── 예 ─→ 건너뜀
                                  └─ 아니오 ─→ 외부 참조 문구 / (단일 필터 시) 반대 기준서 → 신호 True
```

### 설계 노트

- **부정-인지 매칭(채택)** vs **구조화 `needs_external` 신뢰 + 오버라이드 제거(대안 B)**: B는 기존 5개 테스트 계약과 안전망을 깨뜨려 v1.0 직전 리스크가 커, 보수적으로 전자를 택했습니다.
- 신호 판정 자체의 정교화(형태소/의존구문 기반)는 코드 `!TODO`로 남긴 후속 과제입니다.

---

## 체크리스트

- [x] 단위 테스트 전체 통과 (289 passed, 5 skipped)
- [x] evaluate 단위 31건 통과 (신규 회귀 4건 포함)
- [x] 기존 `check_external_reference` / `validate_verdict` 계약 회귀 없음
- [x] 정확성 영향 없음 — CRAG 공회전(비용·지연)만 제거
- [ ] (후속) #96 정확도 라운드를 이 브랜치 위에서 실행해 호출 수 정상화 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)
