### PR TITLE
fix: 대량 적재 임베딩 CPU 포화·메모리 누적 OOM 완화 (#117)

### DIFF
--- a/src/db/vector_store.py
+++ b/src/db/vector_store.py
@@ -10,6 +10,8 @@
 #     (전체 롤백 대신 부분 커밋을 택한 이유: 수천 청크 인덱싱 중 일시 장애로
 #      전부 버리는 것보다 partial 상태를 드러내고 재시도하는 쪽이 운영상 단순하다)
 
+import ctypes
+import gc
 import json
 
 from psycopg import errors, sql
@@ -66,6 +68,23 @@ def _ensure_collection(collection: str) -> None:
     except Exception as e:
         logger.error(f"컬렉션 생성 실패: collection={collection}, {e}")
         raise DatabaseQueryError(f"컬렉션 생성 실패: {e}", node="index")
+
+
+def _release_heap() -> None:
+    """배치 처리 후 해제된 힙을 OS에 돌려줘 장시간 적재의 RSS 누적을 줄인다.
+
+    torch 텐서는 refcount로 즉시 해제되지만 glibc malloc은 free된 영역을 아레나에 보유해 RSS가 계단식으로 증가한다(컨테이너 OOM의 주 원인).
+    gc 수집 후 malloc_trim(0)으로 빈 영역을 커널에 반환한다.
+    malloc_trim은 Linux glibc 전용이라 그 외 플랫폼(예: macOS, musl)에서는 조용히 건너뛴다.
+
+    NOTE: 누적 메모리의 근본 차단은 워커 재기동(프로세스 단위 적재 분할)이며, 더 큰 변경이라 별도 이슈로 분리한다.
+    이 함수는 인프로세스 범위의 완화책이다.
+    """
+    gc.collect()
+    try:
+        ctypes.CDLL("libc.so.6").malloc_trim(0)
+    except (OSError, AttributeError):
+        pass
 
 
 def _upsert_batch(collection: str, batch: list[RetrievedChunk], vectors: list[list[float]]) -> None:
@@ -155,6 +174,9 @@ def index_documents(chunks: list[RetrievedChunk], collection: str) -> IndexingRe
             # CM-002(임베딩)·SE-102(DB) 등 배치 단위 실패 — 부분 커밋 정책에 따라 다음 배치 계속
             logger.error(f"[{e.error_type}] 배치 인덱싱 실패 (chunks[{start}:{start + len(batch)}]): {e.message}")
             continue
+        finally:
+            # 배치마다 해제 힙을 OS에 반환해 누적 RSS 증가를 완화한다
+            _release_heap()
 
     if success_count == len(chunks):
         status = "success"

--- a/src/utils/config.py
+++ b/src/utils/config.py
@@ -1,3 +1,4 @@
+import os
 from datetime import timezone, timedelta
 
 # 파이프라인 전역 설정값
@@ -28,6 +29,17 @@ SEARCH_TIMEOUT_SECONDS: int = 5
 EMBEDDING_MODEL: str = "nlpai-lab/KURE-v1"
 EMBEDDING_DIM: int = 1024   # KURE-v1(bge-m3 기반) 벡터 차원 수 → pgvector vector(1024)
 EMBEDDING_MAX_TOKENS: int = 8192    # KURE-v1 컨텍스트 한도 — 초과 청크는 IX-201로 스킵(부분 커밋)
+
+# 임베딩 실행 자원 설정 — 대량 적재 시 CPU 포화·메모리 누적 OOM 완화용. 모두 env로 override.
+#   - EMBEDDING_DEVICE: "auto"면 _get_model()이 cuda → mps → cpu 순으로 가용 디바이스를 고른다.
+#     Docker on Mac 컨테이너에는 MPS/Metal이 패스스루되지 않아 자동으로 cpu가 된다. 호스트 네이티브
+#     실행 시 mps로 잡혀 CPU 부하를 GPU로 넘긴다. "cpu"/"mps"/"cuda"로 강제 지정도 가능.
+#   - EMBEDDING_NUM_THREADS: torch intra-op 스레드 상한. 0이면 max(1, cpu_count-2)로 자동 산정해 전 코어 점유(오버서브스크립션, 관측된 1000%+ CPU)를 막는다.
+#   - EMBEDDING_ENCODE_BATCH_SIZE: model.encode 미니배치 크기. 작을수록 인코딩 1회 peak 메모리가 준다
+#     (sentence-transformers는 길이순 정렬 후 이 크기로 쪼개 패딩 낭비도 함께 줄인다).
+EMBEDDING_DEVICE: str = os.getenv("EMBEDDING_DEVICE", "auto")
+EMBEDDING_NUM_THREADS: int = int(os.getenv("EMBEDDING_NUM_THREADS", "0"))
+EMBEDDING_ENCODE_BATCH_SIZE: int = int(os.getenv("EMBEDDING_ENCODE_BATCH_SIZE", "16"))
 
 # gpt-5.4-mini 컨텍스트 윈도우(400K) 중 컨텍스트 입력에 할당할 안전 한도
 # o200k_base 토크나이저 기준 한국어 ~0.5 토큰/글자 (즉 1 토큰 ≈ 2~3 글자)

--- a/src/utils/embedding.py
+++ b/src/utils/embedding.py
@@ -5,9 +5,15 @@
 # KURE-v1은 BAAI/bge-m3를 한국어 검색에 파인튜닝한 모델로, 1024차원 벡터를 출력한다.
 # normalize_embeddings=True로 단위 벡터를 생성해 pgvector의 코사인 거리(<=>)와 정합을 맞춘다.
 
+import os
 import threading
 
-from src.utils.config import EMBEDDING_MODEL
+from src.utils.config import (
+    EMBEDDING_DEVICE,
+    EMBEDDING_ENCODE_BATCH_SIZE,
+    EMBEDDING_MODEL,
+    EMBEDDING_NUM_THREADS,
+)
 from src.utils.exception import LLMAPIConnectionError, NodeType
 from src.utils.logger import get_logger
 
@@ -17,20 +23,62 @@ _model = None               # SentenceTransformer 싱글톤 (최초 호출 시 1
 _lock = threading.Lock()    # 멀티스레드 환경에서 모델 이중 로드 방지
 
 
+def _resolve_device(setting: str) -> str:
+    """임베딩 실행 디바이스를 결정한다.
+
+    "auto"면 가용성에 따라 cuda → mps → cpu 순으로 고른다. 
+    Docker on Mac 컨테이너에는 MPS/Metal이 패스스루되지 않아 자동으로 cpu가 된다. 
+    "cpu"/"mps"/"cuda" 같은 명시값은 그대로 사용한다.
+    torch는 여기서 지연 임포트해 모듈 기동 비용을 늘리지 않는다.
+    """
+    if setting and setting != "auto":
+        return setting
+    import torch
+
+    if torch.cuda.is_available():
+        return "cuda"
+    if torch.backends.mps.is_available():
+        return "mps"
+    return "cpu"
+
+
+def _resolve_thread_count() -> int:
+    """torch intra-op 스레드 상한을 결정한다.
+
+    EMBEDDING_NUM_THREADS>0이면 그 값을, 0(자동)이면 max(1, cpu_count-2)를 쓴다.
+    전 코어 점유로 인한 오버서브스크립션(관측된 1000%+ CPU)을 막아 발열·경합을 줄인다.
+    """
+    if EMBEDDING_NUM_THREADS > 0:
+        return EMBEDDING_NUM_THREADS
+    return max(1, (os.cpu_count() or 1) - 2)
+
+
 def _get_model():
     """SentenceTransformer 모델을 lazy 싱글톤으로 반환한다.
 
     - 지연 임포트: sentence_transformers는 torch를 끌고 오므로 모듈 import 시점이 아닌 최초 임베딩 시점에 로드하여, DB 전용 경로(예: sparse 검색)의 기동 비용을 막는다.
     - _lock으로 보호해 동시 호출 시 모델이 두 번 로드되지 않도록 한다.
+    - 디바이스·스레드 상한은 모델 로드 시점에 1회 적용한다.
     """
     global _model
     if _model is None:
         with _lock:
             if _model is None:
+                import torch
                 from sentence_transformers import SentenceTransformer
 
-                logger.info(f"임베딩 모델 로드 시작: {EMBEDDING_MODEL}")
-                _model = SentenceTransformer(EMBEDDING_MODEL)
+                threads = _resolve_thread_count()
+                torch.set_num_threads(threads)
+                device = _resolve_device(EMBEDDING_DEVICE)
+                if device == "mps":
+                    # 일부 연산이 MPS 미구현일 때 CPU로 폴백해 런타임 크래시를 막는다
+                    os.environ.setdefault("PYTORCH_ENABLE_MPS_FALLBACK", "1")
+
+                logger.info(
+                    f"임베딩 모델 로드 시작: {EMBEDDING_MODEL} "
+                    f"(device={device}, torch_threads={threads})"
+                )
+                _model = SentenceTransformer(EMBEDDING_MODEL, device=device)
                 logger.info("임베딩 모델 로드 완료")
     return _model
 
@@ -49,7 +97,13 @@ def embed_texts(texts: list[str], node: NodeType = "index") -> list[list[float]]
         return []
     try:
         model = _get_model()
-        vectors = model.encode(texts, normalize_embeddings=True)
+        # batch_size로 인코딩 1회 peak 메모리를 묶는다. sentence-transformers가 입력을 길이순
+        # 정렬해 이 크기로 미니배치를 만들므로 긴 노드 1개가 배치 전체를 끌어올리는 패딩 낭비도 준다.
+        vectors = model.encode(
+            texts,
+            normalize_embeddings=True,
+            batch_size=EMBEDDING_ENCODE_BATCH_SIZE,
+        )
         return [vector.tolist() for vector in vectors]
     except Exception as e:
         logger.error(f"임베딩 생성 실패: {e}")

--- a/tests/unit/utils/test_embedding.py
+++ b/tests/unit/utils/test_embedding.py
@@ -1,0 +1,123 @@
+"""
+[FUNC-003/FUNC-005] 공유 임베딩 모듈 단위 테스트
+
+대상 모듈: src/utils/embedding.py
+검증 범위:
+    - _resolve_device(): "auto" 시 cuda→mps→cpu 우선순위, 명시값 패스스루
+    - _resolve_thread_count(): 명시값/자동(max(1, cpu-2)) 산정
+    - embed_texts(): 빈 입력 처리, encode 호출 인자(batch_size/normalize), 실패 시 CM-002 변환
+
+torch/SentenceTransformer는 mock으로 차단해 실제 모델 로드 없이 논리만 검증한다.
+"""
+import pytest
+from unittest.mock import patch, MagicMock
+
+import numpy as np
+
+from src.utils.config import EMBEDDING_DIM, EMBEDDING_ENCODE_BATCH_SIZE
+from src.utils.exception import LLMAPIConnectionError
+
+
+@pytest.mark.unit
+class TestResolveDevice:
+    """_resolve_device() — 디바이스 자동 선택/명시 패스스루"""
+
+    def test_explicit_device_passthrough(self):
+        """'auto'가 아닌 명시값은 가용성 검사 없이 그대로 반환한다"""
+        from src.utils.embedding import _resolve_device
+
+        assert _resolve_device("cpu") == "cpu"
+        assert _resolve_device("mps") == "mps"
+        assert _resolve_device("cuda") == "cuda"
+
+    def test_auto_prefers_cuda(self):
+        """auto: CUDA가 가용하면 cuda를 고른다 (최우선)"""
+        from src.utils.embedding import _resolve_device
+
+        with patch("torch.cuda.is_available", return_value=True), \
+             patch("torch.backends.mps.is_available", return_value=True):
+            assert _resolve_device("auto") == "cuda"
+
+    def test_auto_falls_back_to_mps(self):
+        """auto: CUDA가 없고 MPS만 가용하면 mps를 고른다"""
+        from src.utils.embedding import _resolve_device
+
+        with patch("torch.cuda.is_available", return_value=False), \
+             patch("torch.backends.mps.is_available", return_value=True):
+            assert _resolve_device("auto") == "mps"
+
+    def test_auto_falls_back_to_cpu(self):
+        """auto: 가속기가 없으면 cpu (Docker on Mac 컨테이너 경로)"""
+        from src.utils.embedding import _resolve_device
+
+        with patch("torch.cuda.is_available", return_value=False), \
+             patch("torch.backends.mps.is_available", return_value=False):
+            assert _resolve_device("auto") == "cpu"
+
+
+@pytest.mark.unit
+class TestResolveThreadCount:
+    """_resolve_thread_count() — torch intra-op 스레드 상한 산정"""
+
+    def test_explicit_thread_count_used(self):
+        """EMBEDDING_NUM_THREADS>0이면 그 값을 그대로 쓴다"""
+        from src.utils import embedding
+
+        with patch.object(embedding, "EMBEDDING_NUM_THREADS", 4):
+            assert embedding._resolve_thread_count() == 4
+
+    def test_auto_derives_from_cpu_count(self):
+        """0(자동)이면 max(1, cpu_count-2)로 산정해 전 코어 점유를 막는다"""
+        from src.utils import embedding
+
+        with patch.object(embedding, "EMBEDDING_NUM_THREADS", 0), \
+             patch("os.cpu_count", return_value=12):
+            assert embedding._resolve_thread_count() == 10
+
+    def test_auto_never_below_one(self):
+        """코어 수가 적어도 최소 1스레드는 보장한다"""
+        from src.utils import embedding
+
+        with patch.object(embedding, "EMBEDDING_NUM_THREADS", 0), \
+             patch("os.cpu_count", return_value=1):
+            assert embedding._resolve_thread_count() == 1
+
+
+@pytest.mark.unit
+class TestEmbedTexts:
+    """embed_texts() — 인코딩 인자 및 예외 변환"""
+
+    def test_empty_input_returns_empty(self):
+        """빈 입력은 모델 로드 없이 빈 리스트를 반환한다"""
+        from src.utils.embedding import embed_texts
+
+        with patch("src.utils.embedding._get_model") as mock_get:
+            assert embed_texts([]) == []
+            mock_get.assert_not_called()    # 빈 입력에 모델 로드 비용을 쓰지 않음
+
+    def test_encode_called_with_batch_size_and_normalize(self):
+        """encode가 정규화 옵션과 EMBEDDING_ENCODE_BATCH_SIZE로 호출되는지 검증"""
+        from src.utils.embedding import embed_texts
+
+        mock_model = MagicMock()
+        mock_model.encode.return_value = np.array([[0.1] * EMBEDDING_DIM, [0.2] * EMBEDDING_DIM])
+
+        with patch("src.utils.embedding._get_model", return_value=mock_model):
+            result = embed_texts(["가", "나"])
+
+        assert len(result) == 2 # 가, 나
+        assert len(result[0]) == EMBEDDING_DIM
+        _, kwargs = mock_model.encode.call_args
+        assert kwargs["normalize_embeddings"] is True
+        assert kwargs["batch_size"] == EMBEDDING_ENCODE_BATCH_SIZE
+
+    def test_encode_failure_raises_cm002(self):
+        """인코딩 실패는 DB 오류가 아니라 임베딩 모델 호출 실패(LLMAPIConnectionError, CM-002)로 변환한다"""
+        from src.utils.embedding import embed_texts
+
+        mock_model = MagicMock()
+        mock_model.encode.side_effect = RuntimeError("OOM")
+
+        with patch("src.utils.embedding._get_model", return_value=mock_model):
+            with pytest.raises(LLMAPIConnectionError):
+                embed_texts(["가"])


### PR DESCRIPTION
## 개요

대량 적재(`main.py ingest`, 전체 33장 ≈ 1,042청크) 시 KURE-v1(CPU) 임베딩이 **전 코어를 포화**시키고 **메모리를 누적**해 OS에 `Killed`(SIGKILL, OOM)되던 문제(#117)를 **인프로세스 범위**에서 완화합니다. 디바이스/스레드/인코딩 배치 크기를 설정 가능하게 만들고, 배치마다 해제된 힙을 OS에 반환합니다. 모든 설정은 기본값으로 즉시 적용되며 env로 override할 수 있습니다.

> 범위 합의: 본 PR은 "내 PC에서 더 안정적으로 돌리기"(인프로세스 튜닝)로 한정합니다. 누적 메모리의 근본 차단(워커 재기동)과 실행 위치 아키텍처(thin client + 추론 서비스 분리)는 별도 이슈로 분리했습니다(#150, #151).

---

## 변경 사항

### 신규 구현

- **`tests/unit/utils/test_embedding.py`** — 임베딩 모듈 단위 테스트 10 케이스 (디바이스 우선순위/명시 패스스루, 스레드 상한 산정, encode 인자, CM-002 변환)

### 수정

- **`src/utils/embedding.py`**
  - `_resolve_device()` — `EMBEDDING_DEVICE=auto`면 `cuda → mps → cpu` 순으로 가용 디바이스 선택. torch는 지연 임포트
  - `_resolve_thread_count()` — `torch.set_num_threads()` 상한 산정(0이면 `max(1, cpu_count-2)`)
  - `embed_texts()` — `model.encode(..., batch_size=EMBEDDING_ENCODE_BATCH_SIZE)`로 인코딩 1회 peak 메모리 제한
- **`src/utils/config.py`** — `EMBEDDING_DEVICE` / `EMBEDDING_NUM_THREADS` / `EMBEDDING_ENCODE_BATCH_SIZE` 추가 (모두 env override)
- **`src/db/vector_store.py`** — `_release_heap()` 추가, `index_documents` 배치 루프 `finally`에서 호출. `gc.collect()` + `malloc_trim(0)`으로 해제 힙을 커널에 반환(누적 RSS 완화)

---

## 아키텍처

### 원인 → 대응 매핑

| #117 원인 가설 | 대응 |
|---|---|
| ③ CPU 추론 — 코어 전부 점유, 스레드 오버서브스크립션(관측 1000~1123%) | `torch.set_num_threads` 상한 + 디바이스 자동선택(가속기 있으면 offload) |
| ② 배치 패딩 비효율 — 긴 노드 1개가 배치 전체 연산량을 끌어올림 | `encode(batch_size=…)` — ST가 길이순 정렬 후 이 크기로 미니배치 → 패딩 낭비 축소 |
| ① 장시간 단일 프로세스 누적 메모리 | `gc.collect()` + `malloc_trim(0)`으로 배치마다 힙 OS 반환 (인프로세스 완화) |

### 디바이스 자동 선택 (`device=auto`)

`cuda` 가용 → `cuda` / 아니면 `mps` 가용 → `mps` / 그 외 → `cpu`. `mps` 선택 시 `PYTORCH_ENABLE_MPS_FALLBACK=1`을 기본 설정해 미구현 op 크래시를 방지합니다.

### 플랫폼/실행 경로별 동작 (graceful degradation)

재현된 적재 경로는 `docker exec … ingest`(컨테이너 = `python:3.12-slim`, **glibc**)이며, **호스트 OS와 무관하게 컨테이너 안에서 동일하게 동작**합니다.

| 실행 환경 | device | 스레드 상한 | batch_size | malloc_trim 힙반환 |
|---|---|---|---|---|
| Docker(리눅스 glibc, 문서화된 경로) | cpu | ✓ | ✓ | **✓** |
| Win 네이티브 + NVIDIA | cuda | ✓ | ✓ | skip |
| Win/Mac 네이티브 (GPU 없음/glibc 아님) | cpu/mps | ✓ | ✓ | skip(무에러) |

`malloc_trim`은 Linux glibc 전용이라 macOS/Windows/musl에선 `OSError`/`AttributeError`로 조용히 건너뜁니다(크래시 없음).

---

## 체크리스트

- [x] 임베딩 모듈 단위 테스트 통과 (10/10)
- [x] 전체 unit 스위트 통과 (295 passed, 5 skipped)
- [x] 기존 `vector_store` 부분 커밋/멱등 upsert 정책 동작 유지 (배치 루프에 `finally` 추가만)
- [x] 모든 신규 설정 기본값 즉시 적용 + env override 검증
- [x] macOS/Windows에서 `_release_heap()` graceful no-op (예외 미발생)
- [ ] 누적 메모리 근본 차단(워커 재기동) — 후속 #150
- [ ] 임베딩 실행 위치 아키텍처 결정 — 후속 #151

Closes #117
