### PR TITLE
chore: 미사용 커스텀 예외 클래스 정리 (CM-003/PS-001/PS-002/OT-101/OT-102) (#139)

### DIFF
--- a/docs/func_interfaces.md
+++ b/docs/func_interfaces.md
@@ -29,7 +29,7 @@
 - **입력**: 마크다운 경로 또는 `ParsedDocument`
 - **출력**: `OntologyGraph`(노드 `Standard`/`Section`/`Subsection` + edges) → `RetrievedChunk[]`(score=0.0, metadata.ontology_node_id)
 - **진입**: `build_graph(md_path, standard_id, standard_type)` → `chunk_graph(graph, source_path)`
-- **에러**: OT-101(순환참조), OT-102(중복노드), OT-103(구조파싱실패)
+- **에러**: OT-103(구조파싱실패). OT-101(순환참조)/OT-102(중복노드)는 검증 미구현으로 클래스 제거됨(#139) — 검증 로직 도입 시 재정의.
 
 ## FUNC-003 — 인덱싱 (`src/db/vector_store.py`, `src/utils/embedding.py`)
 - **입력**: `list[RetrievedChunk]`, collection(기본 `chunks`)
@@ -84,9 +84,8 @@
 |---|---|---|---|
 | CM-001 | * | 설정/환경변수 누락 | ✗ |
 | CM-002 | * | LLM API 호출 실패 | ✓ |
-| CM-003 | * | 문서 파싱 실패 | ✗ |
-| PS-001/002 | parse | 파일 없음 / 미지원 포맷 | ✗ |
-| OT-101/102/103 | ontology | 순환참조 / 중복노드 / 구조파싱 | ✗ |
+| CM-003 | * | 문서 파싱 실패 (클래스 존재, 미배선 — 착지점 `DoclingParser.parse`) | ✗ |
+| OT-103 | ontology | 구조파싱실패 | ✗ |
 | SE-101/102/103 | search/index | 타임아웃 / DB / 결과없음 | ✓/✓/✗ |
 | RR-201/202 | rerank | 모델실패 / 임계미달 | ✓/✗ |
 | IX-201 | index | 임베딩 토큰 한도 초과 | ✗ |
@@ -94,3 +93,5 @@
 | GN-401/402 | generate | 응답포맷 / 컨텍스트길이 | ✓/✗ |
 
 > `ErrorLog`(timestamp KST, node, error_type, message)로 `GraphState.error_logs`에 누적.
+>
+> #139에서 제거된 미사용 분류: PS-001(파일 없음)/PS-002(미지원 포맷), OT-101(순환참조)/OT-102(중복노드). 검증 로직을 실제 구현하는 시점에 raise 사이트와 함께 재도입한다.

--- a/src/parse/parser.py
+++ b/src/parse/parser.py
@@ -116,6 +116,7 @@ class DoclingParser:
         # ── 2단계: PDF 분석 ──
         # converter.convert()가 PDF를 읽고 AI 모델로 레이아웃을 분석합니다.
         # result.document에 분석 결과(텍스트, 표, 구조 정보)가 담깁니다.
+        # TODO(#139): converter.convert() / 아래 export_to_markdown() 실패를 DocumentParseError(CM-003, node="parse")로 감싸 raw 예외 전파를 차단할 것.
         converter = self._get_converter()
         result = converter.convert(str(file_path))
         doc = result.document

--- a/src/utils/exception.py
+++ b/src/utils/exception.py
@@ -1,6 +1,5 @@
 from datetime import datetime
 from typing import Literal
-from pathlib import Path
 
 # src.models.state의 ErrorLog 타입 참조 (타입 힌팅용)
 from src.models.state import ErrorLog
@@ -69,49 +68,25 @@ class LLMAPIConnectionError(AccountingRAGError):
 class DocumentParseError(AccountingRAGError):
     """
     [CM-003] 문서 파일 파싱에 실패했을 때 발생하는 예외입니다.
-    Windows 파일 경로 호환을 위해 pathlib.Path를 사용한 추가 정보를 지원합니다.
+    착지점: src/parse/parser.py DoclingParser.parse() (converter.convert() /
+    export_to_markdown() 실패 변환). raise 사이트 도입 전까지는 미배선 상태.
     """
-    def __init__(self, message: str, node: NodeType, file_path: Path | None = None):
-        msg = f"{message} (File: {file_path})" if file_path else message
-        super().__init__(message=msg, node=node, error_type="CM-003", is_retryable=False)
+    def __init__(self, message: str, node: NodeType):
+        super().__init__(message=message, node=node, error_type="CM-003", is_retryable=False)
 
 
 # ==========================================
 # 2. Parse Exceptions (PS) -> node: "parse"
 # ==========================================
-
-class DocumentNotFoundError(AccountingRAGError):
-    """
-    [PS-001] 지정된 경로에 문서 파일이 존재하지 않을 때 발생하는 예외입니다.
-    """
-    def __init__(self, message: str):
-        super().__init__(message=message, node="parse", error_type="PS-001", is_retryable=False)
-
-class UnsupportedFormatError(AccountingRAGError):
-    """
-    [PS-002] 시스템에서 지원하지 않는 파일 형식일 때 발생하는 예외입니다.
-    """
-    def __init__(self, message: str):
-        super().__init__(message=message, node="parse", error_type="PS-002", is_retryable=False)
+# PS-001(DocumentNotFoundError) / PS-002(UnsupportedFormatError)는 검증 로직
+# 미구현·사용처 0건으로 제거. 파서가 파일 부재/포맷 검증을 실제로 구현하는 시점에 필요한 것만 raise 사이트와 함께 재도입한다(YAGNI).
 
 
 # ==========================================
 # 3. Ontology Exceptions (OT) -> node: "ontology"
 # ==========================================
-
-class CircularReferenceError(AccountingRAGError):
-    """
-    [OT-101] 조항 간의 참조 관계가 순환을 형성했을 때 발생하는 예외입니다.
-    """
-    def __init__(self, message: str):
-        super().__init__(message=message, node="ontology", error_type="OT-101", is_retryable=False)
-
-class DuplicateNodeError(AccountingRAGError):
-    """
-    [OT-102] 동일한 조항 번호가 중복으로 정의되었을 때 발생하는 예외입니다.
-    """
-    def __init__(self, message: str):
-        super().__init__(message=message, node="ontology", error_type="OT-102", is_retryable=False)
+# OT-101(CircularReferenceError, 순환참조) / OT-102(DuplicateNodeError, 중복노드)는 청커에 해당 검증이 없고 사용처 0건이라 #139에서 제거
+# 순환/중복 검증 구현 시 검증 로직과 함께 재정의한다. 실사용은 OT-103뿐이다.
 
 class OntologyParsingError(AccountingRAGError):
     """


### PR DESCRIPTION
## 개요

`src/utils/exception.py`에 정의됐지만 `src`/`tests` 전역에서 **import·raise가 0건**인 미사용(dead-taxonomy) 커스텀 예외 클래스를 정리합니다. 유지 비용만 발생시키는 빈 분류를 제거해 예외 체계를 실제 사용과 정합하게 맞추는 작업으로, MVP 예외 정책(`docs/exception_policy.md`)의 **R2 — 처분 없는 미사용 분류 제거(YAGNI)** 에 해당합니다.

Closes #139

---

## 변경 사항

### 제거 (사용처 0건 확인)

- **PS-001 `DocumentNotFoundError` / PS-002 `UnsupportedFormatError`** — 파서에 파일 부재·포맷 검증 자체가 미구현. '파일 부재 vs 포맷 미지원'으로 의미가 달라 병합하지 않고, 실제 검증 도입 시 필요한 것만 raise 사이트와 함께 재도입한다.
- **OT-101 `CircularReferenceError` / OT-102 `DuplicateNodeError`** — 청커에 순환참조·중복노드 검증이 없음. 검증 로직 구현 시점에 함께 재정의한다.

### 수정

- **`src/utils/exception.py`** — CM-003 `DocumentParseError`는 곧 도입될 명백한 착지점이라 **유지**하되, 미사용 `file_path` 포매팅 분기를 제거해 표면적 축소(이에 따라 `from pathlib import Path` import도 정리). 제거된 분류는 섹션 주석으로 재도입 조건을 남겨 추적 가능하게 함.
- **`src/parse/parser.py`** — `DoclingParser.parse()`의 `converter.convert()` / `export_to_markdown()`가 raw 예외를 그대로 전파하므로, 이를 `DocumentParseError(CM-003)`로 변환할 착지점에 TODO 부착.
- **`docs/func_interfaces.md`** — FUNC-002 에러 줄과 에러코드 카탈로그를 코드와 정합화 (PS·OT-101/102 행 제거, OT-103만 유지, CM-003 미배선 상태 명시, 하단에 제거 항목 각주).

### 유지

- **OT-103 `OntologyParsingError`** — `src/db/ontology/chunker.py`에서 실제 raise되고 `tests/unit/ontology/test_chunker.py`로 검증되는 유일한 OT 실사용처. 그대로 보존.

---

## 이슈 전제와 실제 트리의 차이 (조정 사항)

이슈 본문은 다음 두 가지를 전제했으나 현재 작업 트리와 달라 실제 코드 기준으로 조정했습니다.

- `docs/func_interfaces.md`가 **부재**한다고 했으나 → 6/14자로 **실재**. 따라서 N/A가 아니라 실제 정합화를 수행.
- 파서가 `src/db/ontology/parser.py`라고 했으나 → 실제 Docling 파서는 `src/parse/parser.py`의 `DoclingParser.parse()`. 이쪽에 CM-003 TODO 부착.

---

## 체크리스트

- [x] OT-101/102·PS-001/002 클래스 제거 + import 회귀 없음 (`uv run pytest --co` 380개 수집 성공)
- [x] 단위 테스트 통과 (`uv run pytest tests/unit` → 299 passed, 5 skipped)
- [x] OT-103 유지 + chunker 테스트 통과
- [x] CM-003: `parser.parse()`에 변환 TODO 부착 + 미사용 `file_path` 분기 제거
- [x] `func_interfaces.md` 정합성 반영 (실재 → N/A 아님)

🤖 Generated with [Claude Code](https://claude.com/claude-code)