### PR TITLE
feat: LangSmith node-boundary 트레이싱 + 케이스 메타데이터 주입 (#164)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -37,3 +37,14 @@ POSTGRES_PASSWORD=accounting_password_example
 #   최고 점수가 이 값 미만이면 재검색(CRAG 루프)을 트리거합니다.
 USE_RERANKER=false
 RERANK_THRESHOLD=0.5
+
+# [LangSmith 트레이싱 — 개발자 디버깅용, 기본 OFF 옵트인]
+# 케이스별 파이프라인 노드 흐름·입출력·지연을 LangSmith로 추적하기 위한 설정입니다(#164).
+# 아래 키가 없거나 LANGCHAIN_TRACING_V2가 true가 아니면 트레이싱은 비활성이며 파이프라인은 정상 동작합니다.
+# 주의: 활성화 시 질의·LLM 답변·검색 컨텍스트가 외부 SaaS(LangSmith)로 전송됩니다. API 키는 레포에 커밋하지 마십시오.
+# LANGCHAIN_TRACING_V2: true로 설정해야 LangGraph 노드 단위 트레이스가 기록됩니다.
+# LANGCHAIN_API_KEY: LangSmith API 키(시크릿). 부재 시 트레이싱은 그대로 비활성.
+# LANGCHAIN_PROJECT: 트레이스가 모일 프로젝트명(미지정 시 LangSmith 기본 프로젝트).
+# LANGCHAIN_TRACING_V2=true
+# LANGCHAIN_API_KEY=ls-your-key-here
+# LANGCHAIN_PROJECT=rag-for-accounting

--- a/README.md
+++ b/README.md
@@ -59,6 +59,21 @@ uv run python -m src.main query "리스 회계처리" --standard GAAP
 
 > 컨테이너(`app`) 안에서 실행하려면 `docker compose exec app uv run python -m src.main ...` 형태로 호출합니다.
 
+### 4. (선택) LangSmith 트레이싱
+
+케이스별로 파이프라인 노드 흐름·입출력·지연을 추적하려면 LangSmith 트레이싱을 켤 수 있습니다(개발자 디버깅용, 기본 OFF). `.env`에 아래 환경변수를 설정합니다.
+
+```bash
+LANGCHAIN_TRACING_V2=true
+LANGCHAIN_API_KEY=ls-your-key-here   # 시크릿 — 레포에 커밋 금지
+LANGCHAIN_PROJECT=rag-for-accounting # 트레이스가 모일 프로젝트명(선택)
+```
+
+- 활성화하면 LangGraph 노드(rewrite→search→rerank→evaluate→generate)와 CRAG 루프·HIL interrupt 분기가 노드 단위 트레이스로 기록됩니다.
+- 벤치마크 측정 경로는 각 트레이스에 케이스 식별 메타데이터(`case_id`, `gold`)를 부착하므로, LangSmith UI에서 케이스별 필터링이 가능합니다.
+- 키가 없거나 `LANGCHAIN_TRACING_V2`가 `true`가 아니면 트레이싱은 비활성이며 파이프라인은 동일하게 동작합니다.
+- ⚠️ 활성화 시 질의·LLM 답변·검색 컨텍스트가 외부 SaaS(LangSmith)로 전송됩니다.
+
 ## 📂 프로젝트 구조
 
 ```

--- a/src/agent/workflow.py
+++ b/src/agent/workflow.py
@@ -458,12 +458,21 @@ def build_workflow(checkpointer: BaseCheckpointSaver | None = None) -> CompiledS
 _CHECKPOINTER: BaseCheckpointSaver = MemorySaver()
 
 
-def _run_config(thread_id: str) -> RunnableConfig:
-    """LangGraph invoke에 전달할 실행 설정. thread_id로 HIL 세션을 식별한다."""
-    return {
+def _run_config(thread_id: str, metadata: dict[str, Any] | None = None) -> RunnableConfig:
+    """LangGraph invoke에 전달할 실행 설정. thread_id로 HIL 세션을 식별한다.
+
+    metadata가 주어지면 RunnableConfig.metadata로 전달한다.
+    LangSmith 트레이싱이 활성(LANGCHAIN_TRACING_V2=true)일 때 케이스 ID·gold 조항 등이 트레이스에 부착되어 분석 시 필터 키로 쓰인다.
+    트레이싱 비활성 시에는 무해하게 무시되므로(LangGraph가 config.metadata를 항상 허용)
+    키 부재 환경에서도 동일하게 정상 동작한다.
+    """
+    run_config: RunnableConfig = {
         "configurable": {"thread_id": thread_id},
         "recursion_limit": MAX_REWRITE_COUNT * 5 + 5,
     }
+    if metadata:
+        run_config["metadata"] = metadata
+    return run_config
 
 
 def _recursion_fallback_response() -> FinalResponse:
@@ -479,6 +488,7 @@ def run_workflow(
     query: str,
     standard_filter: Literal["GAAP", "KIFRS", "ALL"] = "ALL",
     thread_id: str | None = None,
+    metadata: dict[str, Any] | None = None,
 ) -> dict[str, Any]:
     """
     외부에서 워크플로우를 실행하기 위한 진입점 함수.
@@ -487,6 +497,10 @@ def run_workflow(
     thread_id가 주어지지 않으면 새 UUID를 발급한다. 반환 dict에는 항상 thread_id가 포함되어,
     워크플로우가 human_review에서 중단(`__interrupt__` 키 존재)된 경우 클라이언트가 이 값을
     resume_workflow에 전달하여 재개할 수 있다.
+
+    metadata는 LangSmith 트레이스에 부착할 케이스 식별 정보(예: {"case_id", "gold"})로,
+    _run_config를 통해 RunnableConfig.metadata로 전달된다. 
+    트레이싱 비활성 시 무시된다.
     """
     app = build_workflow(checkpointer=_CHECKPOINTER)
 
@@ -501,7 +515,7 @@ def run_workflow(
     try:
         # 정상/중단 반환 시 LangGraph의 invoke()는 dict를 반환하며 값들은 Pydantic 객체를 유지합니다.
         # human_review에서 interrupt가 발생하면 반환 dict에 "__interrupt__" 키가 포함됩니다.
-        result = app.invoke(initial_state, config=_run_config(thread_id))
+        result = app.invoke(initial_state, config=_run_config(thread_id, metadata))
         result["thread_id"] = thread_id
         return result
     except GraphRecursionError:
@@ -521,7 +535,11 @@ def run_workflow(
         raise
 
 
-def resume_workflow(thread_id: str, resume_value: dict[str, Any]) -> dict[str, Any]:
+def resume_workflow(
+    thread_id: str,
+    resume_value: dict[str, Any],
+    metadata: dict[str, Any] | None = None,
+) -> dict[str, Any]:
     """
     human_review에서 interrupt로 중단된 워크플로우를 재개한다.
 
@@ -530,12 +548,15 @@ def resume_workflow(thread_id: str, resume_value: dict[str, Any]) -> dict[str, A
 
     반환 dict에는 thread_id가 포함된다. 사용자가 다시 재작성을 요청하여 또 한 번 중단되면
     반환 dict에 "__interrupt__" 키가 존재하므로, 동일 thread_id로 재차 resume_workflow를 호출한다.
+
+    metadata는 run_workflow와 동일한 케이스 식별 정보를 재개 실행 트레이스에도 부착하기 위한 것으로,
+    호출자가 run_workflow에 넘긴 값을 그대로 전달하면 한 케이스의 run/resume 트레이스가 동일 메타데이터를 공유한다.
     """
     app = build_workflow(checkpointer=_CHECKPOINTER)
     app.step_timeout = 30
 
     try:
-        result = app.invoke(Command(resume=resume_value), config=_run_config(thread_id))
+        result = app.invoke(Command(resume=resume_value), config=_run_config(thread_id, metadata))
         result["thread_id"] = thread_id
         return result
     except GraphRecursionError:

--- a/tests/integration/helpers.py
+++ b/tests/integration/helpers.py
@@ -38,6 +38,8 @@ def run_workflow_to_completion(
             (HIL 루프가 종료되지 않는 회귀를 테스트에서 즉시 검출).
     """
     result = run_workflow(query, standard_filter=standard_filter, **kwargs)
+    # run/resume 트레이스가 동일 케이스 메타데이터를 공유하도록 resume 호출에도 그대로 전달한다.
+    metadata = kwargs.get("metadata")
     guard = 0
     while "__interrupt__" in result:
         guard += 1
@@ -48,5 +50,5 @@ def run_workflow_to_completion(
             )
         thread_id = result.get("thread_id")
         assert thread_id, "interrupt 상태에 thread_id 가 없음 (#79 계약 위반)"
-        result = resume_workflow(thread_id, {"action": "approve"})
+        result = resume_workflow(thread_id, {"action": "approve"}, metadata=metadata)
     return result

--- a/tests/unit/agent/test_workflow.py
+++ b/tests/unit/agent/test_workflow.py
@@ -7,6 +7,8 @@ from src.agent.workflow import (
     early_exit,
     search,
     run_workflow,
+    resume_workflow,
+    _run_config,
 )
 from src.models.state import GraphState
 from src.utils.config import MAX_REWRITE_COUNT
@@ -404,4 +406,74 @@ class TestRunWorkflow:
 
         with pytest.raises(TimeoutError):
             run_workflow("영업권 손상차손 인식 기준은?")
+
+
+@pytest.mark.unit
+class TestRunConfigMetadata:
+    """LangSmith 트레이스용 케이스 메타데이터 주입 경로 단위 테스트"""
+
+    def test_run_config_without_metadata_omits_key(self):
+        """metadata 미지정 시 RunnableConfig에 metadata 키가 없고 기존 키는 유지된다"""
+        cfg = _run_config("tid-1")
+        assert cfg["configurable"]["thread_id"] == "tid-1"
+        assert cfg["recursion_limit"] == MAX_REWRITE_COUNT * 5 + 5
+        assert "metadata" not in cfg
+
+    def test_run_config_attaches_metadata(self):
+        """metadata 지정 시 RunnableConfig.metadata로 그대로 전달된다"""
+        meta = {"case_id": "K-001", "gold": ["1015-10", "1015-12"]}
+        cfg = _run_config("tid-2", meta)
+        assert cfg["metadata"] == meta
+        # thread_id·recursion_limit는 메타데이터와 무관하게 유지
+        assert cfg["configurable"]["thread_id"] == "tid-2"
+
+    def test_run_config_empty_metadata_omits_key(self):
+        """빈 metadata({})는 부착하지 않는다(불필요한 빈 키 방지)"""
+        assert "metadata" not in _run_config("tid-3", {})
+
+    @patch("src.agent.workflow.build_workflow")
+    def test_run_workflow_forwards_metadata_to_config(self, mock_build_workflow):
+        """run_workflow가 metadata를 invoke config로 전달한다"""
+        mock_app = MagicMock()
+        mock_app.invoke.return_value = {"original_query": "q"}
+        mock_build_workflow.return_value = mock_app
+
+        meta = {"case_id": "K-007", "gold": ["1116-9"]}
+        run_workflow("리스 부채 측정", thread_id="t-meta", metadata=meta)
+
+        sent_config = mock_app.invoke.call_args.kwargs["config"]
+        assert sent_config["metadata"] == meta
+
+    @patch("src.agent.workflow.build_workflow")
+    def test_resume_workflow_forwards_metadata_to_config(self, mock_build_workflow):
+        """resume_workflow가 metadata를 invoke config로 전달한다(run/resume 트레이스 일관성)"""
+        mock_app = MagicMock()
+        mock_app.invoke.return_value = {"final_response": "done"}
+        mock_build_workflow.return_value = mock_app
+
+        meta = {"case_id": "K-007", "gold": ["1116-9"]}
+        resume_workflow("t-meta", {"action": "approve"}, metadata=meta)
+
+        sent_config = mock_app.invoke.call_args.kwargs["config"]
+        assert sent_config["metadata"] == meta
+
+    @patch("src.agent.workflow.build_workflow")
+    def test_metadata_path_independent_of_tracing_env(self, mock_build_workflow, monkeypatch):
+        """트레이싱 env 부재(graceful OFF)에서도 메타데이터 주입·정상 완료 — 회귀 가드.
+
+        활성화는 LANGCHAIN_TRACING_V2 환경변수가 전담하며 우리 코드는 이를 읽지 않는다.
+        따라서 트레이싱이 꺼진 환경(키 없음)에서도 파이프라인은 동일하게 완료되고 metadata는 config에 그대로 실린다.
+        """
+        monkeypatch.delenv("LANGCHAIN_TRACING_V2", raising=False)
+        monkeypatch.delenv("LANGCHAIN_API_KEY", raising=False)
+
+        mock_app = MagicMock()
+        mock_app.invoke.return_value = {"original_query": "q", "final_response": "ok"}
+        mock_build_workflow.return_value = mock_app
+
+        meta = {"case_id": "K-001", "gold": ["1015-10"]}
+        result = run_workflow("수익 인식 5단계", metadata=meta)
+
+        assert result["final_response"] == "ok"
+        assert mock_app.invoke.call_args.kwargs["config"]["metadata"] == meta
 

--- a/tests/unit/agent/test_workflow_to_completion.py
+++ b/tests/unit/agent/test_workflow_to_completion.py
@@ -42,7 +42,22 @@ class TestRunWorkflowToCompletion:
 
         assert result is completed
         assert "__interrupt__" not in result
-        mock_resume.assert_called_once_with("t1", {"action": "approve"})
+        mock_resume.assert_called_once_with("t1", {"action": "approve"}, metadata=None)
+
+    def test_forwards_metadata_to_resume(self):
+        """metadata 인자가 run/resume 양쪽에 동일하게 전달된다."""
+        interrupted = {"thread_id": "t1", "__interrupt__": [{"value": {}}]}
+        completed = {"thread_id": "t1", "final_response": "answer"}
+        meta = {"case_id": "K-007", "gold": ["1116-9"]}
+        with patch(
+            "tests.integration.helpers.run_workflow", return_value=interrupted
+        ) as mock_run, patch(
+            "tests.integration.helpers.resume_workflow", return_value=completed
+        ) as mock_resume:
+            run_workflow_to_completion("복잡한 회계 질의", metadata=meta)
+
+        mock_run.assert_called_once_with("복잡한 회계 질의", standard_filter="ALL", metadata=meta)
+        mock_resume.assert_called_once_with("t1", {"action": "approve"}, metadata=meta)
 
     def test_raises_when_loop_never_terminates(self):
         """resume이 계속 interrupt를 반환하면 _MAX_AUTO_APPROVE 초과 시 RuntimeError."""

--- a/tests/utils/benchmark_metrics.py
+++ b/tests/utils/benchmark_metrics.py
@@ -202,7 +202,12 @@ def measure_case(case: BenchmarkCase, k: int) -> CaseResult:
         gold_paras=sorted(gold_paras),
     )
     try:
-        state = run_workflow_to_completion(case.query, standard_filter=case.standard)
+        # 케이스 식별 정보를 LangSmith 트레이스에 부착. 트레이싱 비활성 시 무해하게 무시됨.
+        state = run_workflow_to_completion(
+            case.query,
+            standard_filter=case.standard,
+            metadata={"case_id": case.id, "gold": sorted(gold_paras)},
+        )
     except Exception as e:  # 케이스 격리: 한 건 실패해도 전체 측정 계속
         res.error = f"{type(e).__name__}: {e}"
         res.diag["traceback"] = traceback.format_exc()[-1500:]


### PR DESCRIPTION
## 개요
#164 — LangSmith **node-boundary 트레이싱 + 케이스 메타데이터 주입 경로**를 구현한다. LangSmith 노드 트레이싱 활성화는 `LANGCHAIN_TRACING_V2` 환경변수가 전담(코드가 읽지 않음)하므로, 코드 작업은 트레이스에 케이스 식별 정보를 싣는 **메타데이터 주입 경로**에 집중했다. LLM 호출 레벨 트레이싱(원시 OpenAI/PydanticAI)은 #171로 분리한다.

## 변경 내용
- **메타데이터 주입 경로** (`src/agent/workflow.py`)
  - `_run_config`/`run_workflow`/`resume_workflow`에 `metadata` 인자 추가 → `RunnableConfig.metadata`로 전달. 트레이싱 비활성 시 무해하게 무시(graceful).
  - `run_workflow_to_completion`이 metadata를 resume 호출까지 forward → 한 케이스의 run/resume 트레이스가 동일 메타데이터 공유.
- **하니스 wiring** (`tests/utils/benchmark_metrics.py`): `measure_case`가 `{case_id, gold}`를 부착해 케이스별 트레이스 필터 가능화.
- **문서** (`.env.example`, `README.md`): LangSmith 설정(기본 OFF 옵트인) + 프라이버시 주의(외부 SaaS 전송) 기록.
- **테스트**: `_run_config` 메타데이터 부착/미부착, run·resume forward, 트레이싱 env 부재(graceful-off) 회귀 가드, 헬퍼 metadata forward.

## 검증
- 단위 테스트: `test_workflow.py`(+`TestRunConfigMetadata` 6건) · `test_workflow_to_completion.py` · `test_hil_workflow.py` → **58 passed**
- 라이브 스모크(`TEST-K-GAAP-001` 1건, 실 LLM+LangSmith): 파이프라인 정상 완료, LangSmith 프로젝트 `rag-for-accounting`에 트레이스 도착 확인
  - **DoD #1**: 루트 LangGraph 트레이스 아래 노드 span 9개(`rewrite/human_review/search/rerank/evaluate/generate` + 라우팅) 기록
  - **DoD #2**: 루트 런 metadata에 `case_id`·`gold` 부착 → 케이스별 필터 가능

## DoD
- [x] (자동) 키 부재 시 트레이싱 비활성 + 파이프라인 정상 동작 — 회귀 테스트
- [x] (자동) `_run_config`/`run_workflow`가 케이스 메타데이터를 RunnableConfig.metadata에 실어 전달 — 단위 테스트
- [x] (수동·라이브 1회) LangSmith에 케이스별 노드 단위 트레이스 + 메타데이터 필터 — 스모크 확인
- [x] `.env.example`·README에 설정법·기본 OFF·프라이버시 기록

## 후속
- #171: LLM 호출 레벨 트레이싱(원시 OpenAI `wrap_openai` + PydanticAI OTel→LangSmith)

Closes #164
