### PR TITLE
fix: TimeoutError 재전파 → 구조화 폴백 GraphState 반환 (#131)

### DIFF
--- a/docs/architecture/func_interfaces.md
+++ b/docs/architecture/func_interfaces.md
@@ -77,7 +77,7 @@
 - **라우팅**: `route_after_rewrite`, `route_after_human_review`, `route_after_evaluate`(needs_reretrieval 최우선)
 - **제어 상수**: MAX_REWRITE_COUNT=3, MAX_HIL_COUNT=5
 - **진입**: `run_workflow(query, standard_filter)`, `resume_workflow(thread_id, decision)`
-- **복원력**: `handle_node_errors` 데코레이터(예외→error_logs 기록 후 계속), GraphRecursionError 폴백.
+- **복원력**: `handle_node_errors` 데코레이터(예외→error_logs 기록 후 계속), GraphRecursionError·TimeoutError 폴백(재전파 없이 구조화 GraphState 반환).
 
 ---
 

--- a/docs/architecture/func_interfaces.md
+++ b/docs/architecture/func_interfaces.md
@@ -94,5 +94,6 @@
 | IX-201 | index | 임베딩 토큰 한도 초과 |
 | EV-301/302/303 | evaluate | 평가파싱 / 일관성 / 할루시네이션 |
 | GN-401/402 | generate | 응답포맷 / 컨텍스트길이 |
+| TIMEOUT | workflow | step_timeout 초과(그래프 레벨, 노드 특정 불가 — `exception.py` 아닌 `workflow.py` 폴백이 직접 기록) |
 
 > `ErrorLog`(timestamp KST, node, error_type, message)로 `GraphState.error_logs`에 누적.

--- a/src/agent/workflow.py
+++ b/src/agent/workflow.py
@@ -27,7 +27,7 @@ from src.utils.exception import (
     LLMAPIConnectionError,
 )
 from src.utils.logger import get_logger
-from src.models.state import GraphState
+from src.models.state import GraphState, ErrorLog
 from src.models.schemas import (
     RetrievedChunk, FinalResponse, RerankingResult
 )
@@ -485,6 +485,25 @@ def _recursion_fallback_response() -> FinalResponse:
     )
 
 
+def _timeout_fallback_response() -> FinalResponse:
+    return FinalResponse(
+        answer="처리 시간이 초과되어 답변을 생성하지 못했습니다. 잠시 후 다시 시도해주세요.",
+        citations=[],
+        is_answerable=False,
+        confidence_score=0.0,
+    )
+
+
+def _timeout_error_log(e: TimeoutError) -> ErrorLog:
+    # step_timeout은 그래프 러너가 던지므로 어느 노드에서 초과됐는지 특정할 수 없다 → node="workflow"
+    return {
+        "timestamp": datetime.now(KST).isoformat(),
+        "node": "workflow",
+        "error_type": "TIMEOUT",
+        "message": str(e) or "노드 실행이 step_timeout을 초과했습니다.",
+    }
+
+
 def run_workflow(
     query: str,
     standard_filter: Literal["GAAP", "KIFRS", "ALL"] = "ALL",
@@ -528,12 +547,14 @@ def run_workflow(
         fallback = {k: getattr(initial_state, k) for k in GraphState.model_fields}  # 예시: {'original_query': '....', ...}
         fallback["thread_id"] = thread_id
         return fallback
-    except TimeoutError:
-        # 타임아웃 발생 시
-        # TODO: MVP 단계에서는 타임아웃 발생 시 호출자(API 라우터 등)가 예외를 처리하도록 재전파(re-raise)합니다.
-        # 추후 타임아웃 발생 시 안전한 GraphState 반환 및 error_logs 기록 로직 추가 필요.
-        # traceback을 보존하기 위해 인수 없이 raise를 사용합니다.
-        raise
+    except TimeoutError as e:
+        # 노드 실행이 step_timeout을 초과 — 구조화 반환 계약(#131)에 따라
+        # GraphRecursionError와 동일하게 폴백 GraphState + error_logs를 반환한다.
+        initial_state.final_response = _timeout_fallback_response()
+        initial_state.error_logs = initial_state.error_logs + [_timeout_error_log(e)]
+        fallback = {k: getattr(initial_state, k) for k in GraphState.model_fields}
+        fallback["thread_id"] = thread_id
+        return fallback
 
 
 def resume_workflow(
@@ -567,5 +588,11 @@ def resume_workflow(
         fallback["final_response"] = _recursion_fallback_response()
         fallback["thread_id"] = thread_id
         return fallback
-    except TimeoutError:
-        raise
+    except TimeoutError as e:
+        # 재개 중 타임아웃도 재전파 대신 체크포인트 상태 기반 폴백을 반환한다(#131).
+        snapshot = app.get_state(_run_config(thread_id))
+        fallback = dict(snapshot.values)
+        fallback["final_response"] = _timeout_fallback_response()
+        fallback["error_logs"] = list(fallback.get("error_logs", [])) + [_timeout_error_log(e)]
+        fallback["thread_id"] = thread_id
+        return fallback

--- a/src/models/state.py
+++ b/src/models/state.py
@@ -8,7 +8,7 @@ class ErrorLog(TypedDict):
     각 노드 실행 중 발생한 예외 정보를 기록하는 타입 딕셔너리.
     """
     timestamp:  str   # ISO 8601 형식의 한국 표준시(KST, +09:00). 예: "2026-04-19T10:00:00+09:00" (src.utils.config KST 활용)
-    node:       str   # 예외가 발생한 노드명: "rewrite" | "search" | "rerank" | "evaluate" | "generate" | "parse" | "ontology" | "index"
+    node:       str   # 예외가 발생한 노드명: "rewrite" | "search" | "rerank" | "evaluate" | "generate" | "parse" | "ontology" | "index" | "workflow"(그래프 레벨, 노드 특정 불가)
     error_type: str   # 커스텀 에러 코드 (예: "CM-002", "SE-101") 또는 일반 예외 시 "UNKNOWN"
     message:    str   # 에러 상세 메시지
 

--- a/tests/unit/agent/test_workflow.py
+++ b/tests/unit/agent/test_workflow.py
@@ -398,14 +398,50 @@ class TestRunWorkflow:
         assert "재시도" in result["final_response"].answer
 
     @patch("src.agent.workflow.build_workflow")
-    def test_run_workflow_timeout_propagates(self, mock_build_workflow):
-        """TimeoutError 발생 시 예외가 그대로 상위로 전파(raise)되는지 검증"""
+    def test_run_workflow_timeout_fallback(self, mock_build_workflow):
+        """TimeoutError 발생 시 재전파 대신 폴백 dict 반환 검증"""
+        from src.models.schemas import FinalResponse
+
         mock_app = MagicMock()
         mock_app.invoke.side_effect = TimeoutError("시간 초과")
         mock_build_workflow.return_value = mock_app
 
-        with pytest.raises(TimeoutError):
-            run_workflow("영업권 손상차손 인식 기준은?")
+        result = run_workflow("영업권 손상차손 인식 기준은?")
+
+        assert isinstance(result, dict) # LangGraph 에러 발생 시 폴백 딕셔너리 반환
+        assert result["thread_id"] # 클라이언트 재시도를 위해 항상 포함
+        assert isinstance(result["final_response"], FinalResponse) # FinalResponse 구조화된 응답
+        assert result["final_response"].is_answerable is False # 답변 불가
+        assert "시간이 초과" in result["final_response"].answer # 시간 초과 메시지
+        assert result["error_logs"][-1]["node"] == "workflow" # 에러 발생 노드
+        assert result["error_logs"][-1]["error_type"] == "TIMEOUT" # 에러 타입
+
+
+@pytest.mark.unit
+class TestResumeWorkflow:
+    """resume_workflow() 실행기 단위 테스트"""
+
+    @patch("src.agent.workflow.build_workflow")
+    def test_resume_workflow_timeout_fallback(self, mock_build_workflow):
+        """재개 중 TimeoutError 발생 시 체크포인트 상태 기반 폴백 dict 반환 검증"""
+        from src.models.schemas import FinalResponse
+
+        mock_app = MagicMock()
+        mock_app.invoke.side_effect = TimeoutError("시간 초과")
+        # 체크포인터에 보관된 중간 상태 스냅샷 (search까지 진행된 상황 가정)
+        mock_app.get_state.return_value = MagicMock(
+            values={"original_query": "영업권 손상차손 인식 기준은?", "rewrite_count": 1, "error_logs": []}
+        )
+        mock_build_workflow.return_value = mock_app
+
+        result = resume_workflow("tid-131", {"action": "approve"})
+
+        assert isinstance(result, dict) # LangGraph 에러 발생 시 폴백 딕셔너리 반환
+        assert result["thread_id"] == "tid-131" # 클라이언트 재시도를 위해 항상 포함
+        assert result["rewrite_count"] == 1 # 체크포인트에 보관된 중간 상태가 폴백에 보존된다
+        assert isinstance(result["final_response"], FinalResponse) # FinalResponse 구조화된 응답
+        assert result["final_response"].is_answerable is False # 답변 불가
+        assert result["error_logs"][-1]["error_type"] == "TIMEOUT" # 에러 타입
 
 
 @pytest.mark.unit


### PR DESCRIPTION
> **한 줄 요약(BLUF):** `run_workflow`/`resume_workflow`가 노드 `step_timeout` 초과 시 트레이스백으로 크래시(재전파)하는 대신, GraphRecursionError와 대칭인 **폴백 GraphState + error_logs**를 반환한다 — "구조화된 GraphState 반환" 계약 복원. #195 FastAPI 에러 계약(타임아웃=200 폴백)이 이 동작을 소비한다.

## 변경 사항 (2커밋)

1. `fix:` TimeoutError 재전파 제거 → 구조화 폴백 (e33f405)
   - `_timeout_fallback_response()` — 전용 메시지("처리 시간이 초과되어…")로 재시도 초과(recursion) 폴백 메시지와 구분
   - `_timeout_error_log()` — node="workflow"(step_timeout은 그래프 러너가 던지므로 노드 특정 불가) · error_type="TIMEOUT"
   - `run_workflow`: 재전파 대신 폴백 GraphState 반환(thread_id 포함, GraphRecursionError 경로와 대칭)
   - `resume_workflow`: 체크포인트 스냅샷 복원 후 동일 폴백 주입 — 진행된 중간 상태(rewrite_count 등) 보존
   - `state.py`: `ErrorLog.node` 주석에 "workflow"(그래프 레벨) 등재
   - 테스트: 재전파를 고정하던 테스트를 폴백 검증으로 교체 + `TestResumeWorkflow` 신설(스냅샷 보존 검증)
2. `docs:` 에러코드 카탈로그에 TIMEOUT 행 등재 (13edbd4) — `exception.py` 클래스가 아닌 `workflow.py` 폴백이 직접 기록하는 코드임을 명시. FUNC-009 복원력 서술 동기화 포함(1번 커밋).

## 검증 (DoD)

- #131 수용 기준("폴백 GraphState + error_logs 반환 + 테스트 추가") 충족 — 이슈가 지목한 run_workflow에 더해 동일 문제였던 resume_workflow까지 양 경로 처리
- `tests/unit/agent/test_workflow.py` 36 passed · 전체 unit **400 passed, 2 skipped** (회귀 0)
- 이슈가 지적한 비대칭(GraphRecursionError=폴백 vs TimeoutError=크래시) 해소, MVP 재전파 TODO 주석 제거

## 관련

Closes #131

- **#195**(FastAPI 서버화): 본 PR로 API 에러 계약이 "타임아웃=**200 폴백**(`error_logs`의 TIMEOUT으로 구분, 5xx 아님)"으로 확정 — 이슈 본문 정정 완료
- 후행: **#210** — GraphRecursionError 폴백에도 error_logs 기록(본 PR의 TIMEOUT 폴백과 대칭화, v1.1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MMNKrHxnkxupEceqov56RT
