### PR TITLE
Refactor: 재시도 소진 풀백을 타임아웃 풀백과 동일하게 재구성

### DIFF
--- a/docs/Update/func_interfaces.md
+++ b/docs/Update/func_interfaces.md
@@ -95,5 +95,6 @@
 | EV-301/302/303 | evaluate | 평가파싱 / 일관성 / 할루시네이션 |
 | GN-401/402 | generate | 응답포맷 / 컨텍스트길이 |
 | TIMEOUT | workflow | step_timeout 초과(그래프 레벨, 노드 특정 불가 — `exception.py` 아닌 `workflow.py` 폴백이 직접 기록) |
+| RECURSION_LIMIT | workflow | recursion_limit 초과(재시도 소진, 그래프 레벨·노드 특정 불가 — `workflow.py` 폴백이 직접 기록) |
 
 > `ErrorLog`(timestamp KST, node, error_type, message)로 `GraphState.error_logs`에 누적.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -538,6 +538,22 @@ function Result({ response }: { response: QueryDoneResponse }) {
     );
   }
 
+  // 재시도 소진 폴백도 조항·답변·인용이 비어 있으므로 안내만 간결하게 보여준다.
+  if (response.error_code === "RECURSION_LIMIT") {
+    return (
+      <section style={{ display: "flex", flexDirection: "column", gap: 16 }}>
+        <div className="result-head">
+          <span className="result-kicker">K-ACCOUNTING 검토 결과</span>
+          <span className="pill warn">처리 중단</span>
+        </div>
+        <p className="notice warning">
+          답변 생성 과정이 지연되거나 무한 반복되어 중단되었습니다.
+          조금 더 명확하거나 구체적인 질문을 입력해 주시기 바랍니다.
+        </p>
+      </section>
+    );
+  }
+
   return (
     <section style={{ display: "flex", flexDirection: "column", gap: 16 }}>
       <div className="result-head">

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -46,8 +46,8 @@ export interface QueryDoneResponse {
   answer: string;
   is_answerable: boolean;
   confidence: number;
-  /** 서버가 error_logs에서 파생한 폴백 구분자 — TIMEOUT이면 일시적 실패(재시도 유도). */
-  error_code: "TIMEOUT" | null;
+  /** 서버가 error_logs에서 파생한 폴백 구분자 — TIMEOUT·RECURSION_LIMIT 모두 재시도로 회복 가능. */
+  error_code: "TIMEOUT" | "RECURSION_LIMIT" | null;
   clauses: ClauseOut[];
   citations: CitationOut[];
 }

--- a/src/agent/workflow.py
+++ b/src/agent/workflow.py
@@ -494,6 +494,16 @@ def _timeout_fallback_response() -> FinalResponse:
     )
 
 
+def _recursion_error_log(e: GraphRecursionError) -> ErrorLog:
+    # 재시도 소진(recursion_limit 초과)도 그래프 러너가 던지므로 어느 노드에서 소진됐는지 특정할 수 없다.
+    return {
+        "timestamp": datetime.now(KST).isoformat(),
+        "node": "workflow",
+        "error_type": "RECURSION_LIMIT",
+        "message": str(e) or "최대 재시도 횟수를 초과했습니다.",
+    }
+
+
 def _timeout_error_log(e: TimeoutError) -> ErrorLog:
     # step_timeout은 그래프 러너가 던지므로 어느 노드에서 초과됐는지 특정할 수 없다 → node="workflow"
     return {
@@ -547,17 +557,17 @@ def run_workflow(
         result = app.invoke(initial_state, config=_run_config(thread_id, metadata))
         result["thread_id"] = thread_id
         return result
-    except GraphRecursionError:
-        # GraphRecursionError 발생 시 최선 답변 혹은 답변 불가 상태 반환
+    except GraphRecursionError as e:
+        # 재시도 소진 — TIMEOUT 폴백과 대칭으로 폴백 GraphState + error_logs를 반환한다.
         initial_state.final_response = _recursion_fallback_response()
-        # TODO: 예외 발생 시 error_logs 기록 및 상태 반환 로직 정교화
+        initial_state.error_logs = initial_state.error_logs + [_recursion_error_log(e)]
         # invoke() 결과와 동일한 직렬화 구조 유지를 위해, model_dump() 대신
-        # Pydantic 인스턴스를 값으로 유지하는 dict comprehension 방식을 사용합니다.
-        fallback = {k: getattr(initial_state, k) for k in GraphState.model_fields}  # 예시: {'original_query': '....', ...}
+        # Pydantic 인스턴스를 값으로 유지하는 dict comprehension 방식을 사용한다.
+        fallback = {k: getattr(initial_state, k) for k in GraphState.model_fields}
         fallback["thread_id"] = thread_id
         return fallback
     except TimeoutError as e:
-        # 노드 실행이 step_timeout을 초과 — 구조화 반환 계약(#131)에 따라
+        # 노드 실행이 step_timeout을 초과 — 구조화 반환 계약에 따라
         # GraphRecursionError와 동일하게 폴백 GraphState + error_logs를 반환한다.
         initial_state.final_response = _timeout_fallback_response()
         initial_state.error_logs = initial_state.error_logs + [_timeout_error_log(e)]
@@ -590,11 +600,12 @@ def resume_workflow(
         result = app.invoke(Command(resume=resume_value), config=_run_config(thread_id, metadata))
         result["thread_id"] = thread_id
         return result
-    except GraphRecursionError:
+    except GraphRecursionError as e:
         # 재개 시점에는 initial_state가 없으므로 체크포인트에 보관된 현재 상태를 복원해 폴백을 구성한다.
         snapshot = app.get_state(_run_config(thread_id))
         fallback = dict(snapshot.values)
         fallback["final_response"] = _recursion_fallback_response()
+        fallback["error_logs"] = list(fallback.get("error_logs", [])) + [_recursion_error_log(e)]
         fallback["thread_id"] = thread_id
         return fallback
     except TimeoutError as e:

--- a/src/api/schemas.py
+++ b/src/api/schemas.py
@@ -70,7 +70,7 @@ class QueryDoneResponse(BaseModel):
     answer: str
     is_answerable: bool
     confidence: float
-    error_code: Literal["TIMEOUT"] | None = None
+    error_code: Literal["TIMEOUT", "RECURSION_LIMIT"] | None = None
     clauses: list[ClauseOut]
     citations: list[CitationOut]
 
@@ -86,15 +86,17 @@ class QueryInterruptedResponse(BaseModel):
 WorkflowResponse = QueryDoneResponse | QueryInterruptedResponse
 
 
-def _derive_error_code(error_logs: list[dict]) -> Literal["TIMEOUT"] | None:
+def _derive_error_code(error_logs: list[dict]) -> Literal["TIMEOUT", "RECURSION_LIMIT"] | None:
     """
-    폴백이 기록한 워크플로 레벨 TIMEOUT을 응답 구분자로 파생한다.
+    폴백이 기록한 워크플로 레벨 오류(TIMEOUT·RECURSION_LIMIT)를 응답 구분자로 파생한다.
 
-    GraphRecursionError 폴백은 error_logs를 기록하지 않으므로 None이다
-    TODO! #210에서 v1.1에서 대칭화 예정 — 그 전까지 클라이언트는 일반 답변불가와 구분 불가.
+    타임아웃과 재시도 소진 둘 다 error_logs에 한 줄을 남기므로, 클라이언트가 이 코드로 일시적 실패(재시도 유도)를 일반 답변불가와 구분한다.
+    노드 레벨 에러(CM-002 등)는 폴백 구분자가 아니므로 매핑하지 않는다.
     """
     if any(log.get("error_type") == "TIMEOUT" for log in error_logs):
         return "TIMEOUT"
+    if any(log.get("error_type") == "RECURSION_LIMIT" for log in error_logs):
+        return "RECURSION_LIMIT"
     return None
 
 

--- a/tests/unit/agent/test_workflow.py
+++ b/tests/unit/agent/test_workflow.py
@@ -396,6 +396,8 @@ class TestRunWorkflow:
         assert isinstance(result["final_response"], FinalResponse)
         assert result["final_response"].is_answerable is False
         assert "재시도" in result["final_response"].answer
+        assert result["error_logs"][-1]["node"] == "workflow"               # 에러 발생 노드
+        assert result["error_logs"][-1]["error_type"] == "RECURSION_LIMIT"  # 에러 타입
 
     @patch("src.agent.workflow.build_workflow")
     def test_run_workflow_timeout_fallback(self, mock_build_workflow):
@@ -442,6 +444,30 @@ class TestResumeWorkflow:
         assert isinstance(result["final_response"], FinalResponse) # FinalResponse 구조화된 응답
         assert result["final_response"].is_answerable is False # 답변 불가
         assert result["error_logs"][-1]["error_type"] == "TIMEOUT" # 에러 타입
+
+    @patch("src.agent.workflow.build_workflow")
+    def test_resume_workflow_recursion_fallback(self, mock_build_workflow):
+        """재개 중 GraphRecursionError 발생 시 체크포인트 상태 기반 폴백 dict + RECURSION_LIMIT 로그 반환 검증"""
+        from langgraph.errors import GraphRecursionError
+        from src.models.schemas import FinalResponse
+
+        mock_app = MagicMock()
+        mock_app.invoke.side_effect = GraphRecursionError("최대 재귀 횟수 초과")
+        # 체크포인터에 보관된 중간 상태 스냅샷 (재작성 루프가 한계에 도달한 상황 가정)
+        mock_app.get_state.return_value = MagicMock(
+            values={"original_query": "영업권 손상차손 인식 기준은?", "rewrite_count": 3, "error_logs": []}
+        )
+        mock_build_workflow.return_value = mock_app
+
+        result = resume_workflow("tid-210", {"action": "approve"})
+
+        assert isinstance(result, dict) # LangGraph 에러 발생 시 폴백 딕셔너리 반환
+        assert result["thread_id"] == "tid-210" # 클라이언트 재시도를 위해 항상 포함
+        assert result["rewrite_count"] == 3 # 체크포인트에 보관된 중간 상태가 폴백에 보존된다
+        assert isinstance(result["final_response"], FinalResponse) # FinalResponse 구조화된 응답
+        assert result["final_response"].is_answerable is False # 답변 불가
+        assert result["error_logs"][-1]["node"] == "workflow" # 에러 발생 노드
+        assert result["error_logs"][-1]["error_type"] == "RECURSION_LIMIT" # 에러 타입
 
 
 @pytest.mark.unit

--- a/tests/unit/api/test_schemas.py
+++ b/tests/unit/api/test_schemas.py
@@ -151,6 +151,22 @@ class TestErrorCode:
         assert res.error_code == "TIMEOUT"
         assert res.is_answerable is False
 
+    def test_recursion_fallback_sets_error_code(self):
+        """재시도 소진 폴백 → error_code="RECURSION_LIMIT" 파생"""
+        fallback = _done_result(
+            final_response=FinalResponse(
+                answer="너무 많은 재시도가 발생하여 답변을 생성하지 못했습니다. 질문을 구체화하여 다시 시도해주세요.",
+                citations=[],
+                is_answerable=False,
+                confidence_score=0.0,
+            ),
+            reranked_chunks=[],
+            error_logs=[{**TIMEOUT_LOG, "error_type": "RECURSION_LIMIT"}],
+        )
+        res = to_api_response(fallback)
+        assert res.error_code == "RECURSION_LIMIT"
+        assert res.is_answerable is False
+
     def test_node_level_errors_do_not_set_error_code(self):
         """노드 레벨 에러(CM-002 등)는 폴백 구분자가 아니다 — TIMEOUT만 매핑"""
         node_error = {**TIMEOUT_LOG, "node": "search", "error_type": "CM-002"}

--- a/tests/unit/api/test_server.py
+++ b/tests/unit/api/test_server.py
@@ -128,6 +128,24 @@ class TestQuery:
         assert body["error_code"] == "TIMEOUT"
         assert body["is_answerable"] is False
 
+    def test_recursion_fallback_returns_200_with_error_code(self, client, monkeypatch):
+        """재시도 소진 폴백은 200 done + error_code="RECURSION_LIMIT"이다."""
+        fallback = _done_result(
+            final_response=FinalResponse(
+                answer="너무 많은 재시도가 발생하여 답변을 생성하지 못했습니다. 질문을 구체화하여 다시 시도해주세요.",
+                citations=[],
+                is_answerable=False,
+                confidence_score=0.0,
+            ),
+            error_logs=[{**TIMEOUT_LOG, "error_type": "RECURSION_LIMIT"}],
+        )
+        monkeypatch.setattr("src.api.server.run_workflow", lambda q, standard_filter="ALL": fallback)
+        r = client.post("/query", json={"query": "무한 반복되는 질의"})
+        assert r.status_code == 200
+        body = r.json()
+        assert body["error_code"] == "RECURSION_LIMIT"
+        assert body["is_answerable"] is False
+
     def test_non_accounting_early_exit(self, client, monkeypatch):
         """비회계 질의 조기종료도 정상 done 응답이다(error_code 없음, 안내 answer)."""
         early = _done_result(


### PR DESCRIPTION
## 개요
재시도 소진(GraphRecursionError) 폴백을 #131 타임아웃과 대칭으로 맞춰,
error_logs에 기록하고 API error_code로 파생해 웹 화면까지 전달한다.

## 변경 (workflow→schemas→frontend 세로 슬라이스)
- 백엔드 workflow.py: _recursion_error_log 헬퍼 + run/resume 폴백에서 error_logs 기록
- API schemas.py: _derive_error_code가 RECURSION_LIMIT 파생, error_code Literal 확장
- 프론트 api.ts·App.tsx: 타입 확장 + "처리 중단" early-return 안내(리서치 데스크 UI에 맞춤)
- 문서 func_interfaces.md: 에러코드 카탈로그에 RECURSION_LIMIT 행

## 검증
- 단위 테스트 62 passed (run/resume recursion 폴백·schemas 파생·server 200/error_code)
- 프론트 빌드(tsc + vite) 통과
- origin/dev(275fa89) 위로 rebase — UI 전면 개편과 정합 확인

## 남은 것 (수동)
- 육안 스모크: 실서버에서 재시도 소진 화면이 타임아웃과 구별되는지 확인