### PR TITLE
feat: add interaction_log for operational query/response logging

### DIFF
--- a/src/api/server.py
+++ b/src/api/server.py
@@ -1,6 +1,7 @@
-"""FastAPI 서버 — 회계 기준서 RAG 워크플로의 HTTP 진입점 (#195).
+"""
+FastAPI 서버 — 회계 기준서 RAG 워크플로의 HTTP 진입점
 
-CLI(src/main.py)·Streamlit(app.py)과 동일한 워크플로(run_workflow → resume_workflow)를
+CLI와 동일한 워크플로(run_workflow → resume_workflow)를
 React 프론트엔드가 소비할 수 있게 노출한다. 응답 조립은 src/api/schemas.to_api_response가
 전담하므로 이 모듈은 HTTP 관심사(검증·상태코드·CORS·lifespan)만 다룬다.
 
@@ -15,6 +16,7 @@ from __future__ import annotations
 from contextlib import asynccontextmanager
 import os
 from pathlib import Path
+import time
 from typing import Literal
 
 from fastapi import FastAPI, HTTPException
@@ -25,8 +27,9 @@ from fastapi.staticfiles import StaticFiles
 from pydantic import BaseModel, Field, field_validator
 
 from src.agent.workflow import resume_workflow, run_workflow, thread_exists
-from src.api.schemas import WorkflowResponse, to_api_response
+from src.api.schemas import QueryDoneResponse, WorkflowResponse, to_api_response
 from src.db.connection import close_pool, init_pool
+from src.db.interaction_log import ensure_interaction_log_table, log_interaction
 from src.ingest.parse.page_map import resolve_pdf_path
 from src.utils.config import API_CORS_ORIGINS, PDF_DIR
 from src.utils.logger import get_logger
@@ -60,9 +63,51 @@ def _warmup_embedding() -> None:
 @asynccontextmanager
 async def lifespan(app: FastAPI):
     init_pool()
+    ensure_interaction_log_table()
     _warmup_embedding()
     yield
     close_pool()
+
+
+def _record_interaction(
+    *,
+    endpoint: str,
+    query_text: str,
+    standard_filter: str | None,
+    response: WorkflowResponse,
+    result: dict,
+    elapsed_ms: int,
+) -> None:
+    """/query·/resume 응답 1건을 interaction_log에 남긴다.
+
+    이 함수의 실패는 log_interaction 내부에서 이미 흡수되므로, 
+    호출자(엔드포인트)는 로깅 실패를 신경 쓸 필요 없이 항상 정상 응답을 반환한다.
+    """
+    if isinstance(response, QueryDoneResponse):
+        evaluation = result.get("evaluation")
+        log_interaction(
+            thread_id=response.thread_id,
+            endpoint=endpoint,
+            query=query_text,
+            standard_filter=standard_filter,
+            status="done",
+            answer=response.answer,
+            is_answerable=response.is_answerable,
+            confidence=response.confidence,
+            error_code=response.error_code,
+            evaluation=evaluation,
+            citations=response.citations,
+            elapsed_ms=elapsed_ms,
+        )
+    else:
+        log_interaction(
+            thread_id=response.thread_id,
+            endpoint=endpoint,
+            query=query_text,
+            standard_filter=standard_filter,
+            status="interrupted",
+            elapsed_ms=elapsed_ms,
+        )
 
 
 app = FastAPI(title="회계 기준서 RAG API", lifespan=lifespan)
@@ -108,8 +153,18 @@ def health() -> dict[str, str]:
 @app.post("/query", response_model=WorkflowResponse)
 def query(req: QueryRequest) -> WorkflowResponse:
     """질의 실행 — 완료(done) 또는 HIL 중단(interrupted) 유니언 응답."""
+    start = time.perf_counter()
     result = run_workflow(req.query, standard_filter=req.standard_filter)
-    return to_api_response(result)
+    response = to_api_response(result)
+    _record_interaction(
+        endpoint="query",
+        query_text=req.query,
+        standard_filter=req.standard_filter,
+        response=response,
+        result=result,
+        elapsed_ms=round((time.perf_counter() - start) * 1000),
+    )
+    return response
 
 
 @app.post("/resume", response_model=WorkflowResponse)
@@ -120,8 +175,18 @@ def resume(req: ResumeRequest) -> WorkflowResponse:
     decision: dict = {"action": req.action}
     if req.feedback is not None:
         decision["feedback"] = req.feedback
+    start = time.perf_counter()
     result = resume_workflow(req.thread_id, decision)
-    return to_api_response(result)
+    response = to_api_response(result)
+    _record_interaction(
+        endpoint="resume",
+        query_text=req.feedback or f"[resume:{req.action}]",
+        standard_filter=None,
+        response=response,
+        result=result,
+        elapsed_ms=round((time.perf_counter() - start) * 1000),
+    )
+    return response
 
 
 @app.get("/documents/{document_id}/pdf")

--- a/src/db/interaction_log.py
+++ b/src/db/interaction_log.py
@@ -1,0 +1,113 @@
+# 설계 결정 요약:
+#   - vector_store.py의 임베딩 테이블과는 별도 테이블이다. 로그에는 벡터가 없으므로 pgvector에 의존하지 않는다.
+#   - INSERT 실패는 API 요청을 막지 않는다 — 로깅은 부가 기능이지 핵심 경로가 아니므로, 테이블 미존재·DB 순단 등으로 실패해도 예외를 삼키고 경고만 남긴 뒤 정상 응답을 이어간다.
+#   - evaluation은 EvaluationResult 필드를 그대로 컬럼화한다 — CRAG 판정 축을 SQL로 바로 집계·필터링할 수 있게 하기 위함이다.
+#   - citations는 건수가 가변인 리스트라 컬럼화하지 않고 JSONB 배열로 저장한다.
+
+from typing import Sequence
+
+from psycopg import sql
+from psycopg.types.json import Jsonb
+from pydantic import BaseModel
+
+from src.db.connection import get_pool
+from src.models.schemas import EvaluationResult
+from src.utils.logger import get_logger
+
+logger = get_logger(__name__)
+
+_TABLE = "interaction_log"
+
+
+def ensure_interaction_log_table() -> None:
+    """테이블·인덱스가 없으면 생성한다. 서버 기동(lifespan) 시 1회 호출한다."""
+    try:
+        with get_pool().connection() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    sql.SQL(
+                        """
+                        CREATE TABLE IF NOT EXISTS {table} (
+                            id BIGSERIAL PRIMARY KEY,
+                            created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+                            thread_id TEXT NOT NULL,
+                            endpoint TEXT NOT NULL,
+                            query TEXT NOT NULL,
+                            standard_filter TEXT,
+                            status TEXT NOT NULL,
+                            answer TEXT,
+                            is_answerable BOOLEAN,
+                            confidence DOUBLE PRECISION,
+                            error_code TEXT,
+                            eval_is_relevant BOOLEAN,
+                            eval_needs_external BOOLEAN,
+                            eval_confidence DOUBLE PRECISION,
+                            eval_reasoning TEXT,
+                            citations JSONB,
+                            elapsed_ms INTEGER
+                        )
+                        """
+                    ).format(table=sql.Identifier(_TABLE))
+                )
+                cur.execute(
+                    sql.SQL(
+                        "CREATE INDEX IF NOT EXISTS {index} ON {table} (thread_id)"
+                    ).format(
+                        index=sql.Identifier(f"{_TABLE}_thread_id_idx"),
+                        table=sql.Identifier(_TABLE),
+                    )
+                )
+    except Exception as e:
+        logger.warning(f"interaction_log 테이블 준비 실패 — 운영 로깅 없이 계속 진행: {e}")
+
+
+def log_interaction(
+    *,
+    thread_id: str,
+    endpoint: str,
+    query: str,
+    standard_filter: str | None,
+    status: str,
+    answer: str | None = None,
+    is_answerable: bool | None = None,
+    confidence: float | None = None,
+    error_code: str | None = None,
+    evaluation: EvaluationResult | None = None,
+    citations: Sequence[BaseModel] | None = None,
+    elapsed_ms: int | None = None,
+) -> None:
+    """질의/응답 1건을 interaction_log에 적재한다.
+
+    citations는 model_dump()만 있으면 되므로 src.models.schemas.Citation과
+    src.api.schemas.CitationOut(페이지 필드가 추가된 API 표현) 어느 쪽을 넘겨도 된다.
+
+    실패해도 예외를 올리지 않고 경고만 남긴다 — 운영 로깅이 사용자 응답 경로를
+    막아서는(요청 실패·지연) 안 되기 때문이다.
+    """
+    try:
+        with get_pool().connection() as conn:
+            with conn.cursor() as cur:
+                cur.execute(
+                    sql.SQL(
+                        """
+                        INSERT INTO {table} (
+                            thread_id, endpoint, query, standard_filter, status,
+                            answer, is_answerable, confidence, error_code,
+                            eval_is_relevant, eval_needs_external, eval_confidence, eval_reasoning,
+                            citations, elapsed_ms
+                        ) VALUES (%s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s)
+                        """
+                    ).format(table=sql.Identifier(_TABLE)),
+                    (
+                        thread_id, endpoint, query, standard_filter, status,
+                        answer, is_answerable, confidence, error_code,
+                        evaluation.is_relevant if evaluation is not None else None,
+                        evaluation.needs_external if evaluation is not None else None,
+                        evaluation.confidence if evaluation is not None else None,
+                        evaluation.reasoning if evaluation is not None else None,
+                        Jsonb([c.model_dump() for c in citations]) if citations is not None else None,
+                        elapsed_ms,
+                    ),
+                )
+    except Exception as e:
+        logger.warning(f"interaction_log 적재 실패(무시하고 계속): thread_id={thread_id}, {e}")

--- a/tests/unit/db/test_interaction_log.py
+++ b/tests/unit/db/test_interaction_log.py
@@ -1,0 +1,98 @@
+"""
+interaction_log 단위 테스트 — 운영 질의/응답 로깅
+
+대상 모듈: src/db/interaction_log.py
+검증 범위:
+    - ensure_interaction_log_table(): DDL 실행, 실패 시에도 예외를 올리지 않음
+    - log_interaction(): INSERT 파라미터 구성, 실패 시에도 예외를 올리지 않음(요청 경로 비차단)
+
+DB는 vector_store 단위 테스트와 동일하게 mock으로 차단한다.
+"""
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from src.db.interaction_log import ensure_interaction_log_table, log_interaction
+from src.models.schemas import Citation, EvaluationResult
+
+
+@pytest.fixture
+def mock_db_pool():
+    with patch("src.db.interaction_log.get_pool") as mock_get_pool:
+        mock_pool = MagicMock()
+        mock_conn = MagicMock()
+        mock_cursor = MagicMock()
+        mock_pool.connection.return_value.__enter__.return_value = mock_conn
+        mock_conn.cursor.return_value.__enter__.return_value = mock_cursor
+        mock_get_pool.return_value = mock_pool
+        yield mock_cursor
+
+
+class TestEnsureInteractionLogTable:
+    def test_executes_ddl(self, mock_db_pool):
+        ensure_interaction_log_table()
+        sqls = " ".join(str(call.args[0]) for call in mock_db_pool.execute.call_args_list)
+        assert "CREATE TABLE IF NOT EXISTS" in sqls
+        assert "CREATE INDEX IF NOT EXISTS" in sqls
+
+    def test_does_not_raise_when_ddl_fails(self):
+        """DB 순단 등으로 테이블 준비가 실패해도 서버 기동을 막지 않는다."""
+        with patch("src.db.interaction_log.get_pool", side_effect=RuntimeError("no pool")):
+            ensure_interaction_log_table()  # 예외 없이 반환되어야 함
+
+
+class TestLogInteraction:
+    def test_inserts_done_interaction(self, mock_db_pool):
+        log_interaction(
+            thread_id="t1",
+            endpoint="query",
+            query="재고자산 측정",
+            standard_filter="GAAP",
+            status="done",
+            answer="취득원가로 측정한다.",
+            is_answerable=True,
+            confidence=0.9,
+            error_code=None,
+            evaluation=EvaluationResult(
+                is_relevant=True, needs_external=False, confidence=0.8, reasoning="충분함",
+            ),
+            citations=[
+                Citation(document_id="d1", chunk_id="c1", content="본문", relevance_score=0.7),
+            ],
+            elapsed_ms=1234,
+        )
+        assert mock_db_pool.execute.call_count == 1
+        args = mock_db_pool.execute.call_args.args
+        assert "INSERT INTO" in str(args[0])
+        params = args[1]
+        assert params[0] == "t1"
+        assert params[4] == "done"
+        # eval_is_relevant, eval_needs_external, eval_confidence, eval_reasoning 순서로 컬럼화되어 있어야 한다
+        assert params[9:13] == (True, False, 0.8, "충분함")
+        assert params[13].obj == [
+            {"document_id": "d1", "chunk_id": "c1", "content": "본문", "relevance_score": 0.7},
+        ]
+
+    def test_inserts_none_when_evaluation_absent(self, mock_db_pool):
+        """평가가 아직 없는 경우(HIL 중단 등)에도 eval_* 컬럼은 NULL로 안전하게 들어간다."""
+        log_interaction(
+            thread_id="t9",
+            endpoint="query",
+            query="리스 회계처리",
+            standard_filter=None,
+            status="interrupted",
+        )
+        params = mock_db_pool.execute.call_args.args[1]
+        assert params[9:13] == (None, None, None, None)
+        assert params[13] is None
+
+    def test_does_not_raise_when_insert_fails(self):
+        """적재 실패는 예외를 올리지 않는다 — 로깅이 사용자 응답 경로를 막으면 안 된다."""
+        with patch("src.db.interaction_log.get_pool", side_effect=RuntimeError("no pool")):
+            log_interaction(
+                thread_id="t1",
+                endpoint="query",
+                query="q",
+                standard_filter=None,
+                status="done",
+            )  # 예외 없이 반환되어야 함


### PR DESCRIPTION
## Summary
- 서버 배포 후에도 실제 질의·CRAG 판정·최종 답변을 사후 분석할 수 있도록 /query·/resume 응답을 `interaction_log` 테이블에 적재한다.
- `evaluation`은 `EvaluationResult` 필드(`is_relevant`/`needs_external`/`confidence`/`reasoning`)를 그대로 컬럼화해 SQL로 직접 집계·필터링할 수 있게 하고, `citations`는 건수가 가변이라 JSONB 배열로 저장한다.
- 로깅 실패(테이블 미존재·DB 순단 등)는 예외를 올리지 않고 경고만 남겨, 운영 로깅이 사용자 응답 경로를 막지 않는다.

## Changes
- `src/db/interaction_log.py` (신규): `ensure_interaction_log_table()`·`log_interaction()` 추가
- `src/api/server.py`: lifespan에서 테이블 준비 + `/query`·`/resume` 응답 직전 적재 연결
- `tests/unit/db/test_interaction_log.py` (신규): DDL 실행·INSERT 파라미터 구성·DB 실패 시 무해한 동작 검증

## Test plan
- [x] `uv run pytest tests/unit/db/test_interaction_log.py tests/unit/api/test_server.py` — 19 passed
- [ ] AWS 배포 후 `POSTGRES_*` 환경변수 확인 및 실제 `/query` 호출로 `interaction_log` 적재 확인