### PR TITLE
feat: 답변 중심 UI 개편 — 조항번호 인용·사이드 PDF 패널 + 문단번호 공용 추출 (#255, #259, #260)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,7 +9,9 @@
       "version": "0.0.0",
       "dependencies": {
         "react": "^19.2.7",
-        "react-dom": "^19.2.7"
+        "react-dom": "^19.2.7",
+        "react-markdown": "^10.1.0",
+        "remark-gfm": "^4.0.1"
       },
       "devDependencies": {
         "@types/node": "^24.13.2",
@@ -724,6 +726,54 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/debug": {
+      "version": "4.1.13",
+      "resolved": "https://registry.npmjs.org/@types/debug/-/debug-4.1.13.tgz",
+      "integrity": "sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/ms": "*"
+      }
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/estree-jsx": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/@types/estree-jsx/-/estree-jsx-1.0.5.tgz",
+      "integrity": "sha512-52CcUVNFyfb1A2ALocQw/Dd1BQFNmSdkuC3BkZ6iqhdMfQz7JWOFRuJFloOzjk+6WijU56m9oKXFAXc7o3Towg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "*"
+      }
+    },
+    "node_modules/@types/hast": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.5.tgz",
+      "integrity": "sha512-rp/ezSWaD1m44dPKICGhiskI13nVr7qTloFwDa/IYkhhf5nzwP+zIQcIJh3WIFSBOy/H1PzB40jPjMDksN4F+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/mdast": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/@types/mdast/-/mdast-4.0.4.tgz",
+      "integrity": "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "*"
+      }
+    },
+    "node_modules/@types/ms": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/@types/ms/-/ms-2.1.0.tgz",
+      "integrity": "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA==",
+      "license": "MIT"
+    },
     "node_modules/@types/node": {
       "version": "24.13.2",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.2.tgz",
@@ -738,7 +788,6 @@
       "version": "19.2.17",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
       "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "csstype": "^3.2.2"
@@ -753,6 +802,18 @@
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
+    },
+    "node_modules/@types/unist": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.3.tgz",
+      "integrity": "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q==",
+      "license": "MIT"
+    },
+    "node_modules/@ungap/structured-clone": {
+      "version": "1.3.3",
+      "resolved": "https://registry.npmjs.org/@ungap/structured-clone/-/structured-clone-1.3.3.tgz",
+      "integrity": "sha512-60YRaenCQcVjYEKOcG824+DRGGIQ3VKErcBoAEDJZz5bKIs2ZG+X/H9Nk+Q6EVkwJk5QNApxbrc5QtBSwtrXAg==",
+      "license": "ISC"
     },
     "node_modules/@vitejs/plugin-react": {
       "version": "6.0.3",
@@ -780,12 +841,120 @@
         }
       }
     },
+    "node_modules/bail": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/bail/-/bail-2.0.2.tgz",
+      "integrity": "sha512-0xO6mYd7JB2YesxDKplafRpsiOzPt9V02ddPCLbY1xYGPOX24NTyN50qnUxgCPcSoYMhKpAuBTjQoRZCAkUDRw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/ccount": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
+      "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/character-entities/-/character-entities-2.0.2.tgz",
+      "integrity": "sha512-shx7oQ0Awen/BRIdkjkvz54PnEEI/EjwXDSIZp86/KKdbafHh1Df/RYGBhn4hbe2+uKC9FnT5UCEdyPz3ai9hQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-html4": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/character-entities-html4/-/character-entities-html4-2.1.0.tgz",
+      "integrity": "sha512-1v7fgQRj6hnSwFpq1Eu0ynr/CDEw0rXo2B61qXrLNdHZmPKgb7fqS1a2JwF0rISo9q77jDI8VMEHoApn8qDoZA==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-entities-legacy": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/character-entities-legacy/-/character-entities-legacy-3.0.0.tgz",
+      "integrity": "sha512-RpPp0asT/6ufRm//AJVwpViZbGM/MkjQFxJccQRHmISF/22NBtsHqAWmL+/pmkPWoIUJdWyeVleTl1wydHATVQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/character-reference-invalid": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/character-reference-invalid/-/character-reference-invalid-2.0.1.tgz",
+      "integrity": "sha512-iBZ4F4wRbyORVsu0jPV7gXkOsGYjGHPmAyv+HiHG8gi5PtC9KI2j1+v8/tlibRvjoWX027ypmG/n0HtO5t7unw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/comma-separated-tokens": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/comma-separated-tokens/-/comma-separated-tokens-2.0.3.tgz",
+      "integrity": "sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
-      "dev": true,
       "license": "MIT"
+    },
+    "node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/decode-named-character-reference": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/decode-named-character-reference/-/decode-named-character-reference-1.3.0.tgz",
+      "integrity": "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q==",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
     },
     "node_modules/detect-libc": {
       "version": "2.1.2",
@@ -796,6 +965,47 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/devlop": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/devlop/-/devlop-1.1.0.tgz",
+      "integrity": "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA==",
+      "license": "MIT",
+      "dependencies": {
+        "dequal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/escape-string-regexp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/estree-util-is-identifier-name": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/estree-util-is-identifier-name/-/estree-util-is-identifier-name-3.0.0.tgz",
+      "integrity": "sha512-hFtqIDZTIUZ9BXLb8y4pYGyk6+wekIivNVTcmvk8NoOh+VeRn5y6cEHzbURrWbfp1fIqdVipilzj+lfaadNZmg==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/extend": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
+      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+      "license": "MIT"
     },
     "node_modules/fdir": {
       "version": "6.5.0",
@@ -828,6 +1038,118 @@
       ],
       "engines": {
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/hast-util-to-jsx-runtime": {
+      "version": "2.3.6",
+      "resolved": "https://registry.npmjs.org/hast-util-to-jsx-runtime/-/hast-util-to-jsx-runtime-2.3.6.tgz",
+      "integrity": "sha512-zl6s8LwNyo1P9uw+XJGvZtdFF1GdAkOg8ujOw+4Pyb76874fLps4ueHXDhXWdk6YHQ6OgUtinliG7RsYvCbbBg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/unist": "^3.0.0",
+        "comma-separated-tokens": "^2.0.0",
+        "devlop": "^1.0.0",
+        "estree-util-is-identifier-name": "^3.0.0",
+        "hast-util-whitespace": "^3.0.0",
+        "mdast-util-mdx-expression": "^2.0.0",
+        "mdast-util-mdx-jsx": "^3.0.0",
+        "mdast-util-mdxjs-esm": "^2.0.0",
+        "property-information": "^7.0.0",
+        "space-separated-tokens": "^2.0.0",
+        "style-to-js": "^1.0.0",
+        "unist-util-position": "^5.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/hast-util-whitespace": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/hast-util-whitespace/-/hast-util-whitespace-3.0.0.tgz",
+      "integrity": "sha512-88JUN06ipLwsnv+dVn+OIYOvAuvBMy/Qoi6O7mQHxdPXpjy+Cd6xRkWwux7DKO+4sYILtLBRIKgsdpS2gQc7qw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/html-url-attributes": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/html-url-attributes/-/html-url-attributes-3.0.1.tgz",
+      "integrity": "sha512-ol6UPyBWqsrO6EJySPz2O7ZSr856WDrEzM5zMqp+FJJLGMW35cLYmmZnl0vztAZxRUoNZJFTCohfjuIJ8I4QBQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/inline-style-parser": {
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/inline-style-parser/-/inline-style-parser-0.2.7.tgz",
+      "integrity": "sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==",
+      "license": "MIT"
+    },
+    "node_modules/is-alphabetical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphabetical/-/is-alphabetical-2.0.1.tgz",
+      "integrity": "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-alphanumerical": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-alphanumerical/-/is-alphanumerical-2.0.1.tgz",
+      "integrity": "sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw==",
+      "license": "MIT",
+      "dependencies": {
+        "is-alphabetical": "^2.0.0",
+        "is-decimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-decimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-decimal/-/is-decimal-2.0.1.tgz",
+      "integrity": "sha512-AAB9hiomQs5DXWcRB1rqsxGUstbRroFOPPVAomNk/3XHR5JyEZChOyTWe2oayKnsSsr/kcGqF+z6yuH6HHpN0A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-hexadecimal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/is-hexadecimal/-/is-hexadecimal-2.0.1.tgz",
+      "integrity": "sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/is-plain-obj": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-4.1.0.tgz",
+      "integrity": "sha512-+Pgi+vMuUNkJyExiMBt5IlFoMyKnr5zhJ4Uspz58WOhBF5QoIZkFyNHIbBAtHwzVAgk5RtndVNsDRN61/mmDqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/lightningcss": {
@@ -1103,10 +1425,869 @@
         "url": "https://opencollective.com/parcel"
       }
     },
+    "node_modules/longest-streak": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
+      "integrity": "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/markdown-table": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.4.tgz",
+      "integrity": "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/mdast-util-find-and-replace": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-3.0.2.tgz",
+      "integrity": "sha512-Tmd1Vg/m3Xz43afeNxDIhWRtFZgM2VLyaf4vSTYwudTyeuTneoL3qtWMA5jeLyz/O1vDJmmV4QuScFCA2tBPwg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "escape-string-regexp": "^5.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-from-markdown": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-2.0.3.tgz",
+      "integrity": "sha512-W4mAWTvSlKvf8L6J+VN9yLSqQ9AOAAvHuoDAmPkz4dHf553m5gVj2ejadHJhoJmcmxEnOv6Pa8XJhpxE93kb8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark": "^4.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm/-/mdast-util-gfm-3.1.0.tgz",
+      "integrity": "sha512-0ulfdQOM3ysHhCJ1p06l0b0VKlhU0wuQs3thxZQagjcjPrlFRqY215uZGHHJan9GEAXd9MbfPjFJz+qMkVR6zQ==",
+      "license": "MIT",
+      "dependencies": {
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-gfm-autolink-literal": "^2.0.0",
+        "mdast-util-gfm-footnote": "^2.0.0",
+        "mdast-util-gfm-strikethrough": "^2.0.0",
+        "mdast-util-gfm-table": "^2.0.0",
+        "mdast-util-gfm-task-list-item": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-autolink-literal": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-2.0.1.tgz",
+      "integrity": "sha512-5HVP2MKaP6L+G6YaxPNjuL0BPrq9orG3TsrZ9YXbA3vDw/ACI4MEsnoDpn6ZNm7GnZgtAcONJyPhOP8tNJQavQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-find-and-replace": "^3.0.0",
+        "micromark-util-character": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-footnote/-/mdast-util-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-sqpDWlsHn7Ac9GNZQMeUzPQSMzR6Wv0WKRNvQRg0KqHh02fpTz69Qc1QSseNX29bhz1ROIyNyxExfawVKTm1GQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.1.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-strikethrough": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-strikethrough/-/mdast-util-gfm-strikethrough-2.0.0.tgz",
+      "integrity": "sha512-mKKb915TF+OC5ptj5bJ7WFRPdYtuHv0yTRxK2tJvi+BDqbkiG7h7u/9SI89nRAYcmap2xHQL9D+QG/6wSrTtXg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-table": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-table/-/mdast-util-gfm-table-2.0.0.tgz",
+      "integrity": "sha512-78UEvebzz/rJIxLvE7ZtDd/vIQ0RHv+3Mh5DR96p7cS7HsBhYIICDBCu8csTNWNO6tBWfqXPWekRuj2FNOGOZg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "markdown-table": "^3.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-task-list-item": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-task-list-item/-/mdast-util-gfm-task-list-item-2.0.0.tgz",
+      "integrity": "sha512-IrtvNvjxC1o06taBAVJznEnkiHxLFTzgonUdy8hzFVeDun0uTjxxrRGVaNFqkU1wJR3RBPEfsxmU6jDWPofrTQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdx-expression": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx-expression/-/mdast-util-mdx-expression-2.0.1.tgz",
+      "integrity": "sha512-J6f+9hUp+ldTZqKRSg7Vw5V6MqjATc+3E4gf3CFNcuZNWD8XdyI6zQ8GqH7f8169MM6P7hMBRDVGnn7oHB9kXQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdx-jsx": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdx-jsx/-/mdast-util-mdx-jsx-3.2.0.tgz",
+      "integrity": "sha512-lj/z8v0r6ZtsN/cGNNtemmmfoLAFZnjMbNyLzBafjzikOM+glrjNHPlf6lQDOTccj9n5b0PPihEBbhneMyGs1Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "ccount": "^2.0.0",
+        "devlop": "^1.1.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "parse-entities": "^4.0.0",
+        "stringify-entities": "^4.0.0",
+        "unist-util-stringify-position": "^4.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-mdxjs-esm": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-mdxjs-esm/-/mdast-util-mdxjs-esm-2.0.1.tgz",
+      "integrity": "sha512-EcmOpxsZ96CvlP03NghtH1EsLtr0n9Tm4lPUJUBccV9RwUOneqSycg19n5HGzCf+10LozMRSObtVr3ee1WoHtg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree-jsx": "^1.0.0",
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "mdast-util-to-markdown": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-phrasing": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-4.1.0.tgz",
+      "integrity": "sha512-TqICwyvJJpBwvGAMZjj4J2n0X8QWp21b9l0o7eXyVJ25YNWYbJDVIyD1bZXE6WtV6RmKJVYmQAKWa0zWOABz2w==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-hast": {
+      "version": "13.2.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-13.2.1.tgz",
+      "integrity": "sha512-cctsq2wp5vTsLIcaymblUriiTcZd0CwWtCbLvrOzYCDZoWyMNV8sZ7krj09FSnsiJi3WVsHLM4k6Dq/yaPyCXA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "@ungap/structured-clone": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "trim-lines": "^3.0.0",
+        "unist-util-position": "^5.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-markdown": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-2.1.2.tgz",
+      "integrity": "sha512-xj68wMTvGXVOKonmog6LwyJKrYXZPvlwabaryTjLh9LuvovB/KAH+kvi8Gjj+7rJjsFi23nkUxRQv1KqSroMqA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "@types/unist": "^3.0.0",
+        "longest-streak": "^3.0.0",
+        "mdast-util-phrasing": "^4.0.0",
+        "mdast-util-to-string": "^4.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-decode-string": "^2.0.0",
+        "unist-util-visit": "^5.0.0",
+        "zwitch": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-string/-/mdast-util-to-string-4.0.0.tgz",
+      "integrity": "sha512-0H44vDimn51F0YwvxSJSm0eCDOJTRlmN0R1yBh4HLj9wiV1Dn0QoXGbvFAWj2hSItVTlCmBF1hqKlIyUBVFLPg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/micromark/-/micromark-4.0.2.tgz",
+      "integrity": "sha512-zpe98Q6kvavpCr1NPVSCMebCKfD7CA2NqZ+rykeNhONIJBpc1tFKt9hucLGwha3jNTNI8lHpctWJWoimVF4PfA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@types/debug": "^4.0.0",
+        "debug": "^4.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-core-commonmark": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/micromark-core-commonmark/-/micromark-core-commonmark-2.0.3.tgz",
+      "integrity": "sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "devlop": "^1.0.0",
+        "micromark-factory-destination": "^2.0.0",
+        "micromark-factory-label": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-factory-title": "^2.0.0",
+        "micromark-factory-whitespace": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-html-tag-name": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-subtokenize": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-extension-gfm": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm/-/micromark-extension-gfm-3.0.0.tgz",
+      "integrity": "sha512-vsKArQsicm7t0z2GugkCKtZehqUm31oeGBV/KVSorWSy8ZlNAv7ytjFhvaryUiCUJYqs+NoE6AFhpQvBTM6Q4w==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-extension-gfm-autolink-literal": "^2.0.0",
+        "micromark-extension-gfm-footnote": "^2.0.0",
+        "micromark-extension-gfm-strikethrough": "^2.0.0",
+        "micromark-extension-gfm-table": "^2.0.0",
+        "micromark-extension-gfm-tagfilter": "^2.0.0",
+        "micromark-extension-gfm-task-list-item": "^2.0.0",
+        "micromark-util-combine-extensions": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-autolink-literal": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-2.1.0.tgz",
+      "integrity": "sha512-oOg7knzhicgQ3t4QCjCWgTmfNhvQbDDnJeVu9v81r7NltNCVmhPy1fJRX27pISafdjL+SVc4d3l48Gb6pbRypw==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-footnote": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-footnote/-/micromark-extension-gfm-footnote-2.1.0.tgz",
+      "integrity": "sha512-/yPhxI1ntnDNsiHtzLKYnE3vf9JZ6cAisqVDauhp4CEHxlb4uoOTxOCJ+9s51bIB8U1N1FJ1RXOKTIlD5B/gqw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-core-commonmark": "^2.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-normalize-identifier": "^2.0.0",
+        "micromark-util-sanitize-uri": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-strikethrough": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-strikethrough/-/micromark-extension-gfm-strikethrough-2.1.0.tgz",
+      "integrity": "sha512-ADVjpOOkjz1hhkZLlBiYA9cR2Anf8F4HqZUO6e5eDcPQd0Txw5fxLzzxnEkSkfnD0wziSGiv7sYhk/ktvbf1uw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-classify-character": "^2.0.0",
+        "micromark-util-resolve-all": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-table": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-table/-/micromark-extension-gfm-table-2.1.1.tgz",
+      "integrity": "sha512-t2OU/dXXioARrC6yWfJ4hqB7rct14e8f7m0cbI5hUmDyyIlwv5vEtooptH8INkbLzOatzKuVbQmAYcbWoyz6Dg==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-tagfilter": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-tagfilter/-/micromark-extension-gfm-tagfilter-2.0.0.tgz",
+      "integrity": "sha512-xHlTOmuCSotIA8TW1mDIM6X2O1SiX5P9IuDtqGonFhEK0qgRI4yeC6vMxEV2dgyr2TiD+2PQ10o+cOhdVAcwfg==",
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-task-list-item": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-task-list-item/-/micromark-extension-gfm-task-list-item-2.1.0.tgz",
+      "integrity": "sha512-qIBZhqxqI6fjLDYFTBIa4eivDMnP+OZqsNwmQ3xNLE4Cxwc+zfQEfbs6tzAo2Hjq+bh6q5F+Z8/cksrLFYWQQw==",
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-factory-destination": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-destination/-/micromark-factory-destination-2.0.1.tgz",
+      "integrity": "sha512-Xe6rDdJlkmbFRExpTOmRj9N3MaWmbAgdpSrBQvCFqhezUn4AHqJHbaEnfbVYYiexVSs//tqOdY/DxhjdCiJnIA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-label": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-label/-/micromark-factory-label-2.0.1.tgz",
+      "integrity": "sha512-VFMekyQExqIW7xIChcXn4ok29YE3rnuyveW3wZQWWqF4Nv9Wk5rgJ99KzPvHjkmPXF93FXIbBp6YdW3t71/7Vg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-space": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-space/-/micromark-factory-space-2.0.1.tgz",
+      "integrity": "sha512-zRkxjtBxxLd2Sc0d+fbnEunsTj46SWXgXciZmHq0kDYGnck/ZSGj9/wULTV95uoeYiK5hRXP2mJ98Uo4cq/LQg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-title": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-title/-/micromark-factory-title-2.0.1.tgz",
+      "integrity": "sha512-5bZ+3CjhAd9eChYTHsjy6TGxpOFSKgKKJPJxr293jTbfry2KDoWkhBb6TcPVB4NmzaPhMs1Frm9AZH7OD4Cjzw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-factory-whitespace": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-factory-whitespace/-/micromark-factory-whitespace-2.0.1.tgz",
+      "integrity": "sha512-Ob0nuZ3PKt/n0hORHyvoD9uZhr+Za8sFoP+OnMcnWK5lngSzALgQYKMr9RJVOWLqQYuyn6ulqGWSXdwf6F80lQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-factory-space": "^2.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-character": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-character/-/micromark-util-character-2.1.1.tgz",
+      "integrity": "sha512-wv8tdUTJ3thSFFFJKtpYKOYiGP2+v96Hvk4Tu8KpCAsTMs6yi+nVmGh1syvSCsaxz45J6Jbw+9DD6g97+NV67Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-chunked": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-chunked/-/micromark-util-chunked-2.0.1.tgz",
+      "integrity": "sha512-QUNFEOPELfmvv+4xiNg2sRYeS/P84pTW0TCgP5zc9FpXetHY0ab7SxKyAQCNCc1eK0459uoLI1y5oO5Vc1dbhA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-classify-character": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-classify-character/-/micromark-util-classify-character-2.0.1.tgz",
+      "integrity": "sha512-K0kHzM6afW/MbeWYWLjoHQv1sgg2Q9EccHEDzSkxiP/EaagNzCm7T/WMKZ3rjMbvIpvBiZgwR3dKMygtA4mG1Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-combine-extensions": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-combine-extensions/-/micromark-util-combine-extensions-2.0.1.tgz",
+      "integrity": "sha512-OnAnH8Ujmy59JcyZw8JSbK9cGpdVY44NKgSM7E9Eh7DiLS2E9RNQf0dONaGDzEG9yjEl5hcqeIsj4hfRkLH/Bg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-numeric-character-reference": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-numeric-character-reference/-/micromark-util-decode-numeric-character-reference-2.0.2.tgz",
+      "integrity": "sha512-ccUbYk6CwVdkmCQMyr64dXz42EfHGkPQlBj5p7YVGzq8I7CtjXZJrubAYezf7Rp+bjPseiROqe7G6foFd+lEuw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-decode-string": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-decode-string/-/micromark-util-decode-string-2.0.1.tgz",
+      "integrity": "sha512-nDV/77Fj6eH1ynwscYTOsbK7rR//Uj0bZXBwJZRfaLEJ1iGBR6kIfNmlNqaqJf649EP0F3NWNdeJi03elllNUQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "decode-named-character-reference": "^1.0.0",
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-decode-numeric-character-reference": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-encode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-encode/-/micromark-util-encode-2.0.1.tgz",
+      "integrity": "sha512-c3cVx2y4KqUnwopcO9b/SCdo2O67LwJJ/UyqGfbigahfegL9myoEFoDYZgkT7f36T0bLrM9hZTAaAyH+PCAXjw==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-html-tag-name": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-html-tag-name/-/micromark-util-html-tag-name-2.0.1.tgz",
+      "integrity": "sha512-2cNEiYDhCWKI+Gs9T0Tiysk136SnR13hhO8yW6BGNyhOC4qYFnwF1nKfD3HFAIXA5c45RrIG1ub11GiXeYd1xA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-normalize-identifier": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-normalize-identifier/-/micromark-util-normalize-identifier-2.0.1.tgz",
+      "integrity": "sha512-sxPqmo70LyARJs0w2UclACPUUEqltCkJ6PhKdMIDuJ3gSf/Q+/GIe3WKl0Ijb/GyH9lOpUkRAO2wp0GVkLvS9Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-resolve-all": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-resolve-all/-/micromark-util-resolve-all-2.0.1.tgz",
+      "integrity": "sha512-VdQyxFWFT2/FGJgwQnJYbe1jjQoNTS4RjglmSjTUlpUMa95Htx9NHeYW4rGDJzbjvCsl9eLjMQwGeElsqmzcHg==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-sanitize-uri": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-sanitize-uri/-/micromark-util-sanitize-uri-2.0.1.tgz",
+      "integrity": "sha512-9N9IomZ/YuGGZZmQec1MbgxtlgougxTodVwDzzEouPKo3qFWvymFHWcnDi2vzV1ff6kas9ucW+o3yzJK9YB1AQ==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "micromark-util-character": "^2.0.0",
+        "micromark-util-encode": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-subtokenize": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/micromark-util-subtokenize/-/micromark-util-subtokenize-2.1.0.tgz",
+      "integrity": "sha512-XQLu552iSctvnEcgXw6+Sx75GflAPNED1qx7eBJ+wydBb2KCbRZe+NwvIEEMM83uml1+2WSXpBAcp9IUCgCYWA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "devlop": "^1.0.0",
+        "micromark-util-chunked": "^2.0.0",
+        "micromark-util-symbol": "^2.0.0",
+        "micromark-util-types": "^2.0.0"
+      }
+    },
+    "node_modules/micromark-util-symbol": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/micromark-util-symbol/-/micromark-util-symbol-2.0.1.tgz",
+      "integrity": "sha512-vs5t8Apaud9N28kgCrRUdEed4UJ+wWNvicHLPxCa9ENlYuAY31M0ETy5y1vA33YoNPDFTghEbnh6efaE8h4x0Q==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/micromark-util-types": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-util-types/-/micromark-util-types-2.0.2.tgz",
+      "integrity": "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA==",
+      "funding": [
+        {
+          "type": "GitHub Sponsors",
+          "url": "https://github.com/sponsors/unifiedjs"
+        },
+        {
+          "type": "OpenCollective",
+          "url": "https://opencollective.com/unified"
+        }
+      ],
+      "license": "MIT"
+    },
+    "node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
     "node_modules/nanoid": {
-      "version": "3.3.15",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
-      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "dev": true,
       "funding": [
         {
@@ -1171,6 +2352,31 @@
         }
       }
     },
+    "node_modules/parse-entities": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/parse-entities/-/parse-entities-4.0.2.tgz",
+      "integrity": "sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^2.0.0",
+        "character-entities-legacy": "^3.0.0",
+        "character-reference-invalid": "^2.0.0",
+        "decode-named-character-reference": "^1.0.0",
+        "is-alphanumerical": "^2.0.0",
+        "is-decimal": "^2.0.0",
+        "is-hexadecimal": "^2.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/parse-entities/node_modules/@types/unist": {
+      "version": "2.0.11",
+      "resolved": "https://registry.npmjs.org/@types/unist/-/unist-2.0.11.tgz",
+      "integrity": "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA==",
+      "license": "MIT"
+    },
     "node_modules/picocolors": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -1192,9 +2398,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.16",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
-      "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
+      "version": "8.5.23",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.23.tgz",
+      "integrity": "sha512-g50586zr4bZmwFiTlflMu8E0bDTb5I5gertgwAKmsdUlTQIhZtunzUlD1WSzwcVWPoAVpsrA6vlfCD7oXvRwgg==",
       "dev": true,
       "funding": [
         {
@@ -1212,12 +2418,22 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
       "engines": {
         "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/property-information": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/property-information/-/property-information-7.2.0.tgz",
+      "integrity": "sha512-IAtzIB6sUiWaJYrX9smp3V46pBGbBeLFRGdh25kg1334VcBlD8HzhPeNIWQH9zhGmo2itIe25EHt9dQP7G5hmg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/react": {
@@ -1239,6 +2455,99 @@
       },
       "peerDependencies": {
         "react": "^19.2.7"
+      }
+    },
+    "node_modules/react-markdown": {
+      "version": "10.1.0",
+      "resolved": "https://registry.npmjs.org/react-markdown/-/react-markdown-10.1.0.tgz",
+      "integrity": "sha512-qKxVopLT/TyA6BX3Ue5NwabOsAzm0Q7kAPwq6L+wWDwisYs7R8vZ0nRXqq6rkueboxpkjvLGU9fWifiX/ZZFxQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "devlop": "^1.0.0",
+        "hast-util-to-jsx-runtime": "^2.0.0",
+        "html-url-attributes": "^3.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-rehype": "^11.0.0",
+        "unified": "^11.0.0",
+        "unist-util-visit": "^5.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      },
+      "peerDependencies": {
+        "@types/react": ">=18",
+        "react": ">=18"
+      }
+    },
+    "node_modules/remark-gfm": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-4.0.1.tgz",
+      "integrity": "sha512-1quofZ2RQ9EWdeN34S79+KExV1764+wCUGop5CPL1WGdD0ocPpu91lzPGbwWMECpEpd42kJGQwzRfyov9j4yNg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-gfm": "^3.0.0",
+        "micromark-extension-gfm": "^3.0.0",
+        "remark-parse": "^11.0.0",
+        "remark-stringify": "^11.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-parse": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-11.0.0.tgz",
+      "integrity": "sha512-FCxlKLNGknS5ba/1lmpYijMUzX2esxW5xQqjWxw2eHFfS2MSdaHVINFmhjo+qN1WhZhNimq0dZATN9pH0IDrpA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-from-markdown": "^2.0.0",
+        "micromark-util-types": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-rehype": {
+      "version": "11.1.2",
+      "resolved": "https://registry.npmjs.org/remark-rehype/-/remark-rehype-11.1.2.tgz",
+      "integrity": "sha512-Dh7l57ianaEoIpzbp0PC9UKAdCSVklD8E5Rpw7ETfbTl3FqcOOgq5q2LVDhgGCkaBv7p24JXikPdvhhmHvKMsw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/hast": "^3.0.0",
+        "@types/mdast": "^4.0.0",
+        "mdast-util-to-hast": "^13.0.0",
+        "unified": "^11.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/remark-stringify": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/remark-stringify/-/remark-stringify-11.0.0.tgz",
+      "integrity": "sha512-1OSmLd3awB/t8qdoEOMazZkNsfVTeY4fTsgzcQFdXNq8ToTN4ZGwrMnlda4K6smTFKD+GRV6O48i6Z4iKgPPpw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/mdast": "^4.0.0",
+        "mdast-util-to-markdown": "^2.0.0",
+        "unified": "^11.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/rolldown": {
@@ -1291,6 +2600,48 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/space-separated-tokens": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/space-separated-tokens/-/space-separated-tokens-2.0.2.tgz",
+      "integrity": "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/stringify-entities": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/stringify-entities/-/stringify-entities-4.0.4.tgz",
+      "integrity": "sha512-IwfBptatlO+QCJUo19AqvrPNqlVMpW9YEL2LIVY+Rpv2qsjCGxaDLNRgeGsQWJhfItebuJhsGSLjaBbNSQ+ieg==",
+      "license": "MIT",
+      "dependencies": {
+        "character-entities-html4": "^2.0.0",
+        "character-entities-legacy": "^3.0.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/style-to-js": {
+      "version": "1.1.21",
+      "resolved": "https://registry.npmjs.org/style-to-js/-/style-to-js-1.1.21.tgz",
+      "integrity": "sha512-RjQetxJrrUJLQPHbLku6U/ocGtzyjbJMP9lCNK7Ag0CNh690nSH8woqWH9u16nMjYBAok+i7JO1NP2pOy8IsPQ==",
+      "license": "MIT",
+      "dependencies": {
+        "style-to-object": "1.0.14"
+      }
+    },
+    "node_modules/style-to-object": {
+      "version": "1.0.14",
+      "resolved": "https://registry.npmjs.org/style-to-object/-/style-to-object-1.0.14.tgz",
+      "integrity": "sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==",
+      "license": "MIT",
+      "dependencies": {
+        "inline-style-parser": "0.2.7"
+      }
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.17",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
@@ -1306,6 +2657,26 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/trim-lines": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/trim-lines/-/trim-lines-3.0.1.tgz",
+      "integrity": "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/trough": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/trough/-/trough-2.2.0.tgz",
+      "integrity": "sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/tslib": {
@@ -1336,6 +2707,121 @@
       "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/unified": {
+      "version": "11.0.5",
+      "resolved": "https://registry.npmjs.org/unified/-/unified-11.0.5.tgz",
+      "integrity": "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "bail": "^2.0.0",
+        "devlop": "^1.0.0",
+        "extend": "^3.0.0",
+        "is-plain-obj": "^4.0.0",
+        "trough": "^2.0.0",
+        "vfile": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-is": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/unist-util-is/-/unist-util-is-6.0.1.tgz",
+      "integrity": "sha512-LsiILbtBETkDz8I9p1dQ0uyRUWuaQzd/cuEeS1hoRSyW5E5XGmTzlwY1OrNzzakGowI9Dr/I8HVaw4hTtnxy8g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-position": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-position/-/unist-util-position-5.0.0.tgz",
+      "integrity": "sha512-fucsC7HjXvkB5R3kTCO7kUjRdrS0BJt3M/FPxmHMBOm8JQi2BsHAHFsy27E0EolP8rp0NzXsJ+jNPyDWvOJZPA==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-stringify-position": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/unist-util-stringify-position/-/unist-util-stringify-position-4.0.0.tgz",
+      "integrity": "sha512-0ASV06AAoKCDkS2+xw5RXJywruurpbC4JZSm7nr7MOt1ojAzvyyaO+UxZf18j8FCF6kmzCZKcAgN/yu2gm2XgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/unist-util-visit/-/unist-util-visit-5.1.0.tgz",
+      "integrity": "sha512-m+vIdyeCOpdr/QeQCu2EzxX/ohgS8KbnPDgFni4dQsfSCtpz8UqDyY5GjRru8PDKuYn7Fq19j1CQ+nJSsGKOzg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0",
+        "unist-util-visit-parents": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/unist-util-visit-parents": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/unist-util-visit-parents/-/unist-util-visit-parents-6.0.2.tgz",
+      "integrity": "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-is": "^6.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/vfile/-/vfile-6.0.3.tgz",
+      "integrity": "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "vfile-message": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/vfile-message": {
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/vfile-message/-/vfile-message-4.0.3.tgz",
+      "integrity": "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/unist": "^3.0.0",
+        "unist-util-stringify-position": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
     },
     "node_modules/vite": {
       "version": "8.1.3",
@@ -1413,6 +2899,16 @@
         "yaml": {
           "optional": true
         }
+      }
+    },
+    "node_modules/zwitch": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+      "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     }
   }

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -11,7 +11,9 @@
   },
   "dependencies": {
     "react": "^19.2.7",
-    "react-dom": "^19.2.7"
+    "react-dom": "^19.2.7",
+    "react-markdown": "^10.1.0",
+    "remark-gfm": "^4.0.1"
   },
   "devDependencies": {
     "@types/node": "^24.13.2",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -7,6 +7,8 @@
  * NFR-002: 검색된 조항이 1순위 — 답변보다 먼저 노출한다.
  */
 import { useEffect, useRef, useState } from "react";
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
 import type {
   QueryDoneResponse,
   QueryInterruptedResponse,
@@ -15,6 +17,7 @@ import type {
   WorkflowResponse,
 } from "./api";
 import { checkPdfAvailable, documentPdfUrl, postQuery, postResume } from "./api";
+import { excerptOf, humanNodeTitle, paraChips } from "./clauseDisplay";
 
 const STANDARD_OPTIONS: { value: StandardFilter; label: string }[] = [
   { value: "ALL", label: "전체 기준" },
@@ -519,6 +522,57 @@ function PdfViewerModal({ target, onClose }: { target: ViewerTarget; onClose: ()
   );
 }
 
+/** 문단번호 칩 행 — 다발이면 목록, 개수가 많으면 범위 한 칩으로 축약. */
+function ParaChips({ paras }: { paras: string[] }) {
+  if (paras.length === 0) return null;
+  return (
+    <div className="para-chips">
+      {paraChips(paras).map((p) => (
+        <span key={p} className="para-chip">
+          {p}
+        </span>
+      ))}
+    </div>
+  );
+}
+
+/** 기준서 마크다운 본문 렌더 — 편집기호(####·**·표 |)를 글자로 내보내지 않고 해석한다. */
+function MarkdownContent({ children }: { children: string }) {
+  return (
+    <div className="md-content">
+      <ReactMarkdown remarkPlugins={[remarkGfm]}>{children}</ReactMarkdown>
+    </div>
+  );
+}
+
+/** 조항 본문 — 접힘(첫 문단 발췌) ⇄ 펼침(전문 마크다운 렌더).
+ *  전문을 카드에서 빼지 않는 이유: BYO 환경에서는 PDF가 없어 DB content가 유일한 근거다. */
+function ClauseContent({ content }: { content: string }) {
+  const [open, setOpen] = useState(false);
+  if (open) {
+    return (
+      <div className="clause-expand">
+        <MarkdownContent>{content}</MarkdownContent>
+        <button type="button" className="more-btn" onClick={() => setOpen(false)}>
+          ▴ 접기
+        </button>
+      </div>
+    );
+  }
+  const excerpt = excerptOf(content);
+  return (
+    <div className="clause-expand">
+      {excerpt.kind === "text" && <p className="clause-excerpt">{excerpt.text}</p>}
+      {excerpt.kind === "table-only" && (
+        <p className="clause-excerpt is-table-note">표 형태의 조항입니다 — 펼치면 표로 보입니다.</p>
+      )}
+      <button type="button" className="more-btn" onClick={() => setOpen(true)}>
+        ▾ 더보기
+      </button>
+    </div>
+  );
+}
+
 function Result({ response }: { response: QueryDoneResponse }) {
   const [viewer, setViewer] = useState<ViewerTarget | null>(null);
 
@@ -580,28 +634,32 @@ function Result({ response }: { response: QueryDoneResponse }) {
           <p className="muted">검색된 조항 없음</p>
         ) : (
           <div className="clause-list">
-            {response.clauses.map((c) => (
-              <article key={c.rank} className="clause-card">
-                <div className={`clause-rank r${Math.min(c.rank, 3)}`}>
-                  <span className="num">{String(c.rank).padStart(2, "0")}</span>
-                  <span className="score">{c.score.toFixed(3)}</span>
-                </div>
-                <div className="clause-body">
-                  <div className="clause-title-row">
-                    <span className="clause-title">
-                      {c.chapter}장{c.node_id && ` · ${c.node_id}`}
-                    </span>
-                    <PageButton
-                      documentId={c.document_id}
-                      pageStart={c.page_start}
-                      pageEnd={c.page_end}
-                      onOpen={setViewer}
-                    />
+            {response.clauses.map((c) => {
+              const title = humanNodeTitle(c.node_id, c.document_id);
+              return (
+                <article key={c.rank} className="clause-card">
+                  <div className={`clause-rank r${Math.min(c.rank, 3)}`}>
+                    <span className="num">{String(c.rank).padStart(2, "0")}</span>
+                    <span className="score">{c.score.toFixed(3)}</span>
                   </div>
-                  <p className="clause-content">{c.content}</p>
-                </div>
-              </article>
-            ))}
+                  <div className="clause-body">
+                    <div className="clause-title-row">
+                      <span className="clause-title">
+                        제{c.chapter}장{title && ` · ${title}`}
+                      </span>
+                      <PageButton
+                        documentId={c.document_id}
+                        pageStart={c.page_start}
+                        pageEnd={c.page_end}
+                        onOpen={setViewer}
+                      />
+                    </div>
+                    <ParaChips paras={c.paras} />
+                    <ClauseContent content={c.content} />
+                  </div>
+                </article>
+              );
+            })}
           </div>
         )}
       </div>
@@ -624,7 +682,10 @@ function Result({ response }: { response: QueryDoneResponse }) {
             {response.citations.map((c, i) => (
               <details key={c.chunk_id} className="cite-card">
                 <summary>
-                  <strong>[{i + 1}]</strong> {c.document_id} / {c.chunk_id}
+                  <strong>[{i + 1}]</strong>
+                  {/* 검색된 조항 카드와 같은 표기(제목·칩) — 두 목록에서 같은 조항이 같은 모양으로 보인다 */}
+                  {c.document_id} · {humanNodeTitle(c.chunk_id, c.document_id) || c.chunk_id}
+                  <ParaChips paras={c.paras} />
                   <span className="rel">관련도 {c.relevance_score.toFixed(2)}</span>
                   <PageButton
                     documentId={c.document_id}
@@ -633,7 +694,9 @@ function Result({ response }: { response: QueryDoneResponse }) {
                     onOpen={setViewer}
                   />
                 </summary>
-                <p className="cite-content">{c.content}</p>
+                <div className="cite-content">
+                  <MarkdownContent>{c.content}</MarkdownContent>
+                </div>
               </details>
             ))}
           </div>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -4,12 +4,15 @@
  * 상태머신은 기존과 동일: idle → loading → (interrupted ⇄ loading)* → done | error.
  * 완료된 질의는 exchanges[]에 쌓여 트랜스크립트로 렌더되고(채팅형),
  * 진행 중 상태(loading/HIL/error)는 트랜스크립트 말미에 인라인 카드로 표시된다.
- * NFR-002: 검색된 조항이 1순위 — 답변보다 먼저 노출한다.
+ *
+ * 검색 조항·인용 목록 섹션 없이 답변만 보여주고, 답변 속 인용 마커를 실제 조항 번호로 바꿔 클릭하면 사이드 패널에서 원문(PDF, 미배치 시 인용 본문)을 확인한다.
+ * 검색 조항 데이터는 API에 그대로 남아 있어 화면 정책만 되돌리면 재노출할 수 있다.
  */
 import { useEffect, useRef, useState } from "react";
 import ReactMarkdown from "react-markdown";
 import remarkGfm from "remark-gfm";
 import type {
+  CitationOut,
   QueryDoneResponse,
   QueryInterruptedResponse,
   ResumeAction,
@@ -17,7 +20,7 @@ import type {
   WorkflowResponse,
 } from "./api";
 import { checkPdfAvailable, documentPdfUrl, postQuery, postResume } from "./api";
-import { excerptOf, humanNodeTitle, paraChips } from "./clauseDisplay";
+import { answerSegments, humanNodeTitle, paraChips } from "./clauseDisplay";
 
 const STANDARD_OPTIONS: { value: StandardFilter; label: string }[] = [
   { value: "ALL", label: "전체 기준" },
@@ -194,8 +197,8 @@ export default function App() {
             <div className="empty-state">
               <span className="brand-name">K-Accounting</span>
               <p>
-                회계기준에 대해 질의하세요. 관련 조항을 먼저 검색해 보여드리고,
-                <br />그 조항을 근거로 답변을 생성합니다.
+                회계기준에 대해 질의하세요. 관련 조항을 근거로 답변을 생성하며,
+                <br />답변 속 조항 번호를 누르면 원문을 확인할 수 있습니다.
               </p>
             </div>
           )}
@@ -382,52 +385,25 @@ function HumanReview({
   );
 }
 
-interface ViewerTarget {
-  documentId: string;
-  page: number;
-}
-
-function PageButton({
-  documentId,
-  pageStart,
-  pageEnd,
-  onOpen,
-}: {
-  documentId: string;
-  pageStart: number | null;
-  pageEnd: number | null;
-  onOpen: (target: ViewerTarget) => void;
-}) {
-  // 백필 전/미매칭 청크는 페이지가 없어 버튼을 표시하지 않는다(자연 강등).
-  if (pageStart === null) return null;
-  const label = pageEnd !== null && pageEnd !== pageStart ? `p.${pageStart}–${pageEnd}` : `p.${pageStart}`;
-  return (
-    <button
-      type="button"
-      className="page-btn"
-      onClick={(e) => {
-        e.preventDefault();
-        e.stopPropagation();
-        onOpen({ documentId, page: pageStart });
-      }}
-    >
-      원문 {label}
-    </button>
-  );
-}
-
-function PdfViewerModal({ target, onClose }: { target: ViewerTarget; onClose: () => void }) {
+/**
+ * 인용 사이드 패널 — 답변 속 조항 번호를 누르면 화면 오른쪽에 열린다.
+ * PDF가 서버에 있으면 해당 페이지(백필 전이면 1쪽)를 iframe으로 띄우고, 없으면(BYO 미배치·스캔본 환경) 인용 청크의 본문을 마크다운으로 보여준다
+ */
+function CitationPanel({ citation, onClose }: { citation: CitationOut; onClose: () => void }) {
   const [available, setAvailable] = useState<boolean | null>(null);
-  const [page, setPage] = useState(target.page);
-  const [pageInput, setPageInput] = useState(String(target.page));
-  const panelRef = useRef<HTMLDivElement>(null);
+  const [page, setPage] = useState(citation.page_start ?? 1);
+  const [pageInput, setPageInput] = useState(String(citation.page_start ?? 1));
+  const panelRef = useRef<HTMLElement>(null);
 
   useEffect(() => {
     setAvailable(null);
-    checkPdfAvailable(target.documentId).then(setAvailable);
-  }, [target.documentId]);
+    checkPdfAvailable(citation.document_id).then(setAvailable);
+    const p = citation.page_start ?? 1; // 페이지 백필(#223) 전에는 1쪽부터 연다
+    setPage(p);
+    setPageInput(String(p));
+  }, [citation]);
 
-  // 모달 기본기: 열릴 때 포커스 이동·배경 스크롤 잠금, Escape 닫기, 닫힐 때 포커스 복원.
+  // 패널 기본기: 열릴 때 포커스 이동, Escape 닫기, 닫힐 때 포커스 복원.
   useEffect(() => {
     const opener = document.activeElement instanceof HTMLElement ? document.activeElement : null;
     panelRef.current?.focus();
@@ -435,11 +411,8 @@ function PdfViewerModal({ target, onClose }: { target: ViewerTarget; onClose: ()
       if (e.key === "Escape") onClose();
     };
     document.addEventListener("keydown", onKey);
-    const prevOverflow = document.body.style.overflow;
-    document.body.style.overflow = "hidden";
     return () => {
       document.removeEventListener("keydown", onKey);
-      document.body.style.overflow = prevOverflow;
       opener?.focus();
     };
   }, [onClose]);
@@ -457,22 +430,43 @@ function PdfViewerModal({ target, onClose }: { target: ViewerTarget; onClose: ()
     else setPageInput(String(page));
   };
 
+  const title = humanNodeTitle(citation.chunk_id, citation.document_id) || citation.chunk_id;
+
   return (
-    <div className="viewer-overlay" onClick={onClose}>
-      <div
-        className="viewer-panel"
-        role="dialog"
-        aria-modal="true"
-        aria-labelledby="viewer-title"
-        tabIndex={-1}
-        ref={panelRef}
-        onClick={(e) => e.stopPropagation()}
-      >
-        <div className="viewer-header">
-          <span className="viewer-title" id="viewer-title">
-            원문 — {target.documentId} · {page}쪽
-          </span>
-          {available && (
+    <aside
+      className="side-panel"
+      role="dialog"
+      aria-labelledby="side-panel-title"
+      tabIndex={-1}
+      ref={panelRef}
+    >
+      <div className="viewer-header">
+        <span className="viewer-title" id="side-panel-title">
+          {citation.document_id} · {title}
+        </span>
+        <button type="button" onClick={onClose}>
+          닫기
+        </button>
+      </div>
+      <div className="side-panel-meta">
+        <ParaChips paras={citation.paras} />
+        <span className="rel">관련도 {citation.relevance_score.toFixed(2)}</span>
+      </div>
+      <div className="viewer-body">
+        {available === null && <p className="notice info">원문 문서를 확인하는 중…</p>}
+        {available === false && (
+          <>
+            <p className="notice warning">
+              원본 PDF가 서버에 없어 인용된 본문으로 대신 보여드립니다.
+              운영 환경에 원본 문서를 배치하면 해당 페이지를 바로 볼 수 있습니다.
+            </p>
+            <div className="side-panel-source">
+              <MarkdownContent>{citation.content}</MarkdownContent>
+            </div>
+          </>
+        )}
+        {available && (
+          <>
             <form className="viewer-nav" onSubmit={submitPage}>
               <button type="button" onClick={() => goTo(page - 1)} disabled={page <= 1}>
                 ◀ 이전
@@ -490,35 +484,25 @@ function PdfViewerModal({ target, onClose }: { target: ViewerTarget; onClose: ()
                 다음 ▶
               </button>
             </form>
-          )}
-          <button type="button" onClick={onClose}>
-            닫기
-          </button>
-        </div>
-        <div className="viewer-body">
-          {available === null && <p className="notice info">원문 문서를 확인하는 중…</p>}
-          {available === false && (
-            <p className="notice warning">
-              원본 PDF가 서버에 없습니다. 운영 환경에 원본 문서(PDF_DIR)를 배치하면 해당 페이지를 바로
-              볼 수 있습니다.
-            </p>
-          )}
-          {available && (
             <iframe
               key={page} /* src의 #page 해시만 바뀌면 내장 PDF 뷰어가 재로딩하지 않아 리마운트로 강제 이동한다 */
               className="viewer-frame"
-              title={`${target.documentId} 원문`}
-              src={documentPdfUrl(target.documentId, page)}
+              title={`${citation.document_id} 원문`}
+              src={documentPdfUrl(citation.document_id, page)}
             />
-          )}
-        </div>
-        {/* 6/14 회의 결정: 한국회계기준원 저작권 표기. PDF 표시 여부(available)와 무관하게 뷰어 모달을 열면 항상 노출한다 */}
-        <p className="viewer-copyright">
-          ⓒ 한국회계기준원. 본 문서의 저작권은 한국회계기준원에 있으며, 조항 원문 확인 용도로만
-          제공됩니다.
-        </p>
+            <details className="side-panel-source">
+              <summary>인용된 본문 텍스트</summary>
+              <MarkdownContent>{citation.content}</MarkdownContent>
+            </details>
+          </>
+        )}
       </div>
-    </div>
+      {/* 6/14 회의 결정: 한국회계기준원 저작권 표기. PDF 표시 여부(available)와 무관하게 패널을 열면 항상 노출한다 */}
+      <p className="viewer-copyright">
+        ⓒ 한국회계기준원. 본 문서의 저작권은 한국회계기준원에 있으며, 조항 원문 확인 용도로만
+        제공됩니다.
+      </p>
+    </aside>
   );
 }
 
@@ -545,36 +529,38 @@ function MarkdownContent({ children }: { children: string }) {
   );
 }
 
-/** 조항 본문 — 접힘(첫 문단 발췌) ⇄ 펼침(전문 마크다운 렌더).
- *  전문을 카드에서 빼지 않는 이유: BYO 환경에서는 PDF가 없어 DB content가 유일한 근거다. */
-function ClauseContent({ content }: { content: string }) {
-  const [open, setOpen] = useState(false);
-  if (open) {
-    return (
-      <div className="clause-expand">
-        <MarkdownContent>{content}</MarkdownContent>
-        <button type="button" className="more-btn" onClick={() => setOpen(false)}>
-          ▴ 접기
-        </button>
-      </div>
-    );
-  }
-  const excerpt = excerptOf(content);
+/** 답변 본문 — 인용 마커([1])를 실제 조항 번호((18.9))로 바꿔 클릭 가능하게 렌더한다. */
+function AnswerBody({
+  answer,
+  citations,
+  onOpenRef,
+}: {
+  answer: string;
+  citations: CitationOut[];
+  onOpenRef: (citationIndex: number) => void;
+}) {
   return (
-    <div className="clause-expand">
-      {excerpt.kind === "text" && <p className="clause-excerpt">{excerpt.text}</p>}
-      {excerpt.kind === "table-only" && (
-        <p className="clause-excerpt is-table-note">표 형태의 조항입니다 — 펼치면 표로 보입니다.</p>
+    <p className="answer-text">
+      {answerSegments(answer, citations).map((s, i) =>
+        s.kind === "text" ? (
+          <span key={i}>{s.text}</span>
+        ) : (
+          <button
+            key={i}
+            type="button"
+            className="answer-ref"
+            onClick={() => onOpenRef(s.citationIndex)}
+          >
+            {s.label}
+          </button>
+        ),
       )}
-      <button type="button" className="more-btn" onClick={() => setOpen(true)}>
-        ▾ 더보기
-      </button>
-    </div>
+    </p>
   );
 }
 
 function Result({ response }: { response: QueryDoneResponse }) {
-  const [viewer, setViewer] = useState<ViewerTarget | null>(null);
+  const [panel, setPanel] = useState<CitationOut | null>(null);
 
   // 타임아웃 폴백은 조항·답변·인용이 모두 비어 있으므로 안내만 간결하게 보여준다.
   if (response.error_code === "TIMEOUT") {
@@ -622,88 +608,21 @@ function Result({ response }: { response: QueryDoneResponse }) {
         </span>
       </div>
 
-      {/* NFR-002: 조항 검색이 1순위이므로 답변보다 먼저 노출한다. */}
-      <div style={{ display: "flex", flexDirection: "column", gap: 10 }}>
-        <div className="section-head">
-          <h3 className="section-title">
-            검색된 조항 <span className="accent">상위 {response.clauses.length}건</span>
-          </h3>
-          <span className="section-note">답변은 아래 조항을 근거로 생성됩니다</span>
-        </div>
-        {response.clauses.length === 0 ? (
-          <p className="muted">검색된 조항 없음</p>
-        ) : (
-          <div className="clause-list">
-            {response.clauses.map((c) => {
-              const title = humanNodeTitle(c.node_id, c.document_id);
-              return (
-                <article key={c.rank} className="clause-card">
-                  <div className={`clause-rank r${Math.min(c.rank, 3)}`}>
-                    <span className="num">{String(c.rank).padStart(2, "0")}</span>
-                    <span className="score">{c.score.toFixed(3)}</span>
-                  </div>
-                  <div className="clause-body">
-                    <div className="clause-title-row">
-                      <span className="clause-title">
-                        제{c.chapter}장{title && ` · ${title}`}
-                      </span>
-                      <PageButton
-                        documentId={c.document_id}
-                        pageStart={c.page_start}
-                        pageEnd={c.page_end}
-                        onOpen={setViewer}
-                      />
-                    </div>
-                    <ParaChips paras={c.paras} />
-                    <ClauseContent content={c.content} />
-                  </div>
-                </article>
-              );
-            })}
-          </div>
-        )}
-      </div>
-
+      {/* 답변 중심 레이아웃(7/25 결정) — 검색 조항·인용 목록 섹션 없이 답변만 보여주고,
+          근거 확인은 답변 속 조항 번호 클릭 → 사이드 패널(PDF 또는 본문)로 연결한다. */}
       <div className="answer-block">
         <h3 className="section-title">답변</h3>
-        <p className="answer-text">{response.answer}</p>
-      </div>
-
-      <div style={{ display: "flex", flexDirection: "column", gap: 10 }}>
-        <div className="section-head">
-          <h3 className="section-title">
-            인용 <span className="accent">{response.citations.length}건</span>
-          </h3>
-        </div>
-        {response.citations.length === 0 ? (
-          <p className="muted">인용 없음</p>
-        ) : (
-          <div className="cite-list">
-            {response.citations.map((c, i) => (
-              <details key={c.chunk_id} className="cite-card">
-                <summary>
-                  <strong>[{i + 1}]</strong>
-                  {/* 검색된 조항 카드와 같은 표기(제목·칩) — 두 목록에서 같은 조항이 같은 모양으로 보인다 */}
-                  {c.document_id} · {humanNodeTitle(c.chunk_id, c.document_id) || c.chunk_id}
-                  <ParaChips paras={c.paras} />
-                  <span className="rel">관련도 {c.relevance_score.toFixed(2)}</span>
-                  <PageButton
-                    documentId={c.document_id}
-                    pageStart={c.page_start}
-                    pageEnd={c.page_end}
-                    onOpen={setViewer}
-                  />
-                </summary>
-                <div className="cite-content">
-                  <MarkdownContent>{c.content}</MarkdownContent>
-                </div>
-              </details>
-            ))}
-          </div>
+        <AnswerBody
+          answer={response.answer}
+          citations={response.citations}
+          onOpenRef={(i) => setPanel(response.citations[i])}
+        />
+        {response.citations.length > 0 && (
+          <p className="answer-refs-note">답변 속 조항 번호를 누르면 원문을 확인할 수 있습니다.</p>
         )}
       </div>
 
-      {viewer && <PdfViewerModal target={viewer} onClose={() => setViewer(null)} />}
+      {panel && <CitationPanel citation={panel} onClose={() => setPanel(null)} />}
     </section>
   );
 }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -69,6 +69,8 @@ export default function App() {
   const [stage, setStage] = useState<Stage>({ kind: "idle" });
   const [exchanges, setExchanges] = useState<Exchange[]>([]);
   const [pending, setPending] = useState<Pending | null>(null);
+  // 패널이 열리면 그리드에 컬럼을 추가해 본문 너비를 줄여야 하는데(본문을 가리지 않기 위해), 그 판단은 최상위 레이아웃의 몫이다.
+  const [citationPanel, setCitationPanel] = useState<CitationOut | null>(null);
   const endRef = useRef<HTMLDivElement>(null);
 
   const busy = stage.kind === "loading" || stage.kind === "interrupted";
@@ -138,6 +140,7 @@ export default function App() {
     setStage({ kind: "idle" });
     setQuery("");
     setFeedback("");
+    setCitationPanel(null);
   };
 
   const dismissError = () => {
@@ -147,7 +150,7 @@ export default function App() {
   };
 
   return (
-    <div className="app">
+    <div className={`app${citationPanel ? " with-panel" : ""}`}>
       <aside className="sidebar">
         <div className="brand">
           <span className="brand-name">K-Accounting</span>
@@ -181,9 +184,6 @@ export default function App() {
             </button>
           )}
         </div>
-        <div className="sidebar-foot">
-          답변은 검색된 기준서 조항을 근거로 생성됩니다. 최종 판단 전 원문 확인을 권장합니다.
-        </div>
       </aside>
 
       <main className="main">
@@ -204,7 +204,7 @@ export default function App() {
           )}
 
           {exchanges.map((x, i) => (
-            <ExchangeBlock key={i} index={i} exchange={x} />
+            <ExchangeBlock key={i} index={i} exchange={x} onOpenCitation={setCitationPanel} />
           ))}
 
           {pending && (
@@ -274,6 +274,10 @@ export default function App() {
           </p>
         </div>
       </main>
+
+      {citationPanel && (
+        <CitationPanel citation={citationPanel} onClose={() => setCitationPanel(null)} />
+      )}
     </div>
   );
 }
@@ -303,7 +307,15 @@ function QueryBlock({
   );
 }
 
-function ExchangeBlock({ index, exchange }: { index: number; exchange: Exchange }) {
+function ExchangeBlock({
+  index,
+  exchange,
+  onOpenCitation,
+}: {
+  index: number;
+  exchange: Exchange;
+  onOpenCitation: (c: CitationOut) => void;
+}) {
   return (
     <div id={`exchange-${index}`} style={{ display: "flex", flexDirection: "column", gap: 20 }}>
       <QueryBlock index={index} query={exchange.query} standard={exchange.standard} time={exchange.time} />
@@ -319,7 +331,7 @@ function ExchangeBlock({ index, exchange }: { index: number; exchange: Exchange 
           </p>
         </div>
       )}
-      <Result response={exchange.response} />
+      <Result response={exchange.response} onOpenCitation={onOpenCitation} />
     </div>
   );
 }
@@ -559,8 +571,13 @@ function AnswerBody({
   );
 }
 
-function Result({ response }: { response: QueryDoneResponse }) {
-  const [panel, setPanel] = useState<CitationOut | null>(null);
+function Result({
+  response,
+  onOpenCitation,
+}: {
+  response: QueryDoneResponse;
+  onOpenCitation: (c: CitationOut) => void;
+}) {
 
   // 타임아웃 폴백은 조항·답변·인용이 모두 비어 있으므로 안내만 간결하게 보여준다.
   if (response.error_code === "TIMEOUT") {
@@ -615,14 +632,9 @@ function Result({ response }: { response: QueryDoneResponse }) {
         <AnswerBody
           answer={response.answer}
           citations={response.citations}
-          onOpenRef={(i) => setPanel(response.citations[i])}
+          onOpenRef={(i) => onOpenCitation(response.citations[i])}
         />
-        {response.citations.length > 0 && (
-          <p className="answer-refs-note">답변 속 조항 번호를 누르면 원문을 확인할 수 있습니다.</p>
-        )}
       </div>
-
-      {panel && <CitationPanel citation={panel} onClose={() => setPanel(null)} />}
     </section>
   );
 }

--- a/frontend/src/api.ts
+++ b/frontend/src/api.ts
@@ -15,6 +15,8 @@ export interface ClauseOut {
   /** 원본 PDF 페이지 범위 — 백필 전/미매칭이면 null(원문 보기 버튼 미표시). */
   page_start: number | null;
   page_end: number | null;
+  /** 문단번호 칩 — 서버 공용 규칙 추출·원형 보존(가지번호 유지). 번호가 없는 청크는 빈 배열. */
+  paras: string[];
 }
 
 export interface CitationOut {
@@ -24,6 +26,8 @@ export interface CitationOut {
   relevance_score: number;
   page_start: number | null;
   page_end: number | null;
+  /** 문단번호 칩 — 검색 조항 목록과 같은 규칙이라 두 목록에서 같은 조항이 같은 모양으로 보인다. */
+  paras: string[];
 }
 
 export type ResumeAction = "approve" | "rewrite";

--- a/frontend/src/clauseDisplay.ts
+++ b/frontend/src/clauseDisplay.ts
@@ -1,0 +1,59 @@
+/**
+ * 조항 카드 표시 규칙 — 칩·제목·발췌를 API 응답에서 파생하는 순수 함수 모음.
+ *
+ * 문단번호 추출 자체는 서버 공용 규칙(src/utils/clause_paras.py)이 하고 프론트는 paras를 소비만 한다.
+ * Python↔TypeScript로 규칙이 두 벌이 되면 채점과 화면이 어긋난다. 여기는 "받은 번호를 어떻게 보여줄지"만 담당한다.
+ * React 렌더와 분리해 둔 이유: 표시 규칙은 입력→출력이 명확한 순수 로직이라, 테스트 러너가 갖춰지면 컴포넌트 없이 바로 검증할 수 있다.
+ */
+
+/** 칩이 이 개수를 넘으면 범위 한 칩으로 줄인다 — 다발 청크는 문단이 수십 개라칩을 다 붙이면 카드 머리가 본문보다 길어진다. */
+const MAX_CHIPS = 6;
+
+/** 칩 표시 목록. 예: 8개 문단 → ["6.13 ~ 6.20 · 8개 문단"] 한 칩으로 축약. */
+export function paraChips(paras: string[]): string[] {
+  if (paras.length <= MAX_CHIPS) return paras;
+  return [`${paras[0]} ~ ${paras[paras.length - 1]} · ${paras.length}개 문단`];
+}
+
+/**
+ * 내부 이름표에서 사람이 읽는 제목을 만든다.
+ * 예: "gaap-ch6-s1-최초인식" → "최초인식", "gaap-ch10-용어의_정의-원가" → "용어의 정의 · 원가".
+ *
+ * 카드 제목의 node_id는 시스템이 문서 구조를 정리하려고 붙인 내부 이름표라 회계사가 쓰지 않는다.
+ * 절 코드(s1)와 분할 순번(-2) 세그먼트는 뜻이 없어 걸러낸다.
+ * 칩이 하나도 없는 카드(용어 정의·사례 등)는 이 제목이 유일한 식별 표지가 된다.
+ */
+export function humanNodeTitle(nodeId: string, documentId: string): string {
+  if (!nodeId) return "";
+  const rest = nodeId.startsWith(`${documentId}-`) ? nodeId.slice(documentId.length + 1) : nodeId;
+  const segments = rest
+    .split("-")
+    .filter((seg) => !/^s\d+$/.test(seg) && !/^\d+$/.test(seg));
+  if (segments.length === 0) return "";
+  return segments.join(" · ").replace(/_/g, " ");
+}
+
+export type Excerpt =
+  | { kind: "text"; text: string }
+  | { kind: "table-only" }
+  | { kind: "empty" };
+
+/**
+ * 접힘 상태에 보여줄 발췌 — 첫 문단의 본문 첫 줄(마크다운 기호 제거).
+ *
+ * "질의에 걸린 문단 우선"은 파이프라인에 매칭 신호가 없어 v1에서는 첫 문단으로 확정했다(7/25 결정).
+ * 표만으로 짜인 조항은 발췌가 표 조각(| … |)이 되어 읽을 수 없으므로, 표가 있다는 사실만 알리고 본문은 펼칠 때 표 모양으로 보여준다.
+ */
+export function excerptOf(content: string): Excerpt {
+  let sawTable = false;
+  for (const raw of content.split("\n")) {
+    const line = raw.trim();
+    if (!line || /^#{1,6}\s/.test(line)) continue;
+    if (line.startsWith("|") || /^[-:|\s]+$/.test(line)) {
+      sawTable = true;
+      continue;
+    }
+    return { kind: "text", text: line.replace(/\*\*/g, "") };
+  }
+  return sawTable ? { kind: "table-only" } : { kind: "empty" };
+}

--- a/frontend/src/clauseDisplay.ts
+++ b/frontend/src/clauseDisplay.ts
@@ -1,5 +1,5 @@
 /**
- * 조항 카드 표시 규칙 — 칩·제목·발췌를 API 응답에서 파생하는 순수 함수 모음.
+ * 조항 표시 규칙 — 칩·제목·답변 인용 마커 치환을 API 응답에서 파생하는 순수 함수 모음.
  *
  * 문단번호 추출 자체는 서버 공용 규칙(src/utils/clause_paras.py)이 하고 프론트는 paras를 소비만 한다.
  * Python↔TypeScript로 규칙이 두 벌이 되면 채점과 화면이 어긋난다. 여기는 "받은 번호를 어떻게 보여줄지"만 담당한다.
@@ -33,27 +33,48 @@ export function humanNodeTitle(nodeId: string, documentId: string): string {
   return segments.join(" · ").replace(/_/g, " ");
 }
 
-export type Excerpt =
+export type AnswerSegment =
   | { kind: "text"; text: string }
-  | { kind: "table-only" }
-  | { kind: "empty" };
+  | { kind: "ref"; citationIndex: number; label: string };
+
+const MARKER_RE = /\[(\d+)\]/g;
 
 /**
- * 접힘 상태에 보여줄 발췌 — 첫 문단의 본문 첫 줄(마크다운 기호 제거).
+ * 답변 본문의 인용 마커([1]·[2])를 실제 조항 번호 라벨로 바꾼 세그먼트 열을 만든다.
+ * 예: "…한도로 합니다 [2]." + citations[1].paras=["18.12"] → "…한도로 합니다(18.12)."
  *
- * "질의에 걸린 문단 우선"은 파이프라인에 매칭 신호가 없어 v1에서는 첫 문단으로 확정했다(7/25 결정).
- * 표만으로 짜인 조항은 발췌가 표 조각(| … |)이 되어 읽을 수 없으므로, 표가 있다는 사실만 알리고 본문은 펼칠 때 표 모양으로 보여준다.
+ * 마커↔인용 매핑은 백엔드 extract_citations_from_text와 같은 규칙으로 복원한다:
+ * citations 배열은 마커가 본문에 처음 등장한 순서로 쌓이므로, k번째로 처음 등장한 마커 번호가 citations[k-1]이다.
+ * citations 길이를 넘는 마커(모델이 지어낸 번호는 백엔드가 버린다)는 치환하지 않고 본문 텍스트로 남긴다.
+ * 문단번호가 없는 인용(용어 정의 등)은 조항 번호 대신 [k] 표기를 유지하되 클릭은 가능하다.
  */
-export function excerptOf(content: string): Excerpt {
-  let sawTable = false;
-  for (const raw of content.split("\n")) {
-    const line = raw.trim();
-    if (!line || /^#{1,6}\s/.test(line)) continue;
-    if (line.startsWith("|") || /^[-:|\s]+$/.test(line)) {
-      sawTable = true;
-      continue;
-    }
-    return { kind: "text", text: line.replace(/\*\*/g, "") };
+export function answerSegments(
+  answer: string,
+  citations: { paras: string[] }[],
+): AnswerSegment[] {
+  const firstSeen: number[] = []; // 마커 번호의 첫 등장 순서
+  for (const m of answer.matchAll(MARKER_RE)) {
+    const n = Number(m[1]);
+    if (!firstSeen.includes(n)) firstSeen.push(n);
   }
-  return sawTable ? { kind: "table-only" } : { kind: "empty" };
+  const citationIndexOf = new Map<number, number>();
+  firstSeen.slice(0, citations.length).forEach((n, i) => citationIndexOf.set(n, i));
+
+  const segments: AnswerSegment[] = [];
+  let cursor = 0;
+  for (const m of answer.matchAll(MARKER_RE)) {
+    const index = m.index ?? 0;
+    const ci = citationIndexOf.get(Number(m[1]));
+    if (ci === undefined) continue; // 매핑 불가 마커는 텍스트로 남긴다(cursor를 안 움직임)
+    if (index > cursor) {
+      // 마커 앞의 공백은 지운다 — "합니다 [2]." 를 "합니다(18.12)." 로 붙여 쓴다.
+      segments.push({ kind: "text", text: answer.slice(cursor, index).replace(/\s+$/, "") });
+    }
+    const paras = citations[ci].paras;
+    const label = paras.length > 0 ? `(${paras[0]}${paras.length > 1 ? " 외" : ""})` : `[${ci + 1}]`;
+    segments.push({ kind: "ref", citationIndex: ci, label });
+    cursor = index + m[0].length;
+  }
+  if (cursor < answer.length) segments.push({ kind: "text", text: answer.slice(cursor) });
+  return segments;
 }

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -84,7 +84,8 @@ a:hover {
 .brand {
   display: flex;
   align-items: baseline;
-  flex-wrap: wrap; /* 브랜드명이 길어 서브 카피는 자연스럽게 다음 줄로 */
+  flex-wrap: wrap;
+  /* 브랜드명이 길어 서브 카피는 자연스럽게 다음 줄로 */
   gap: 2px 10px;
   padding: 0 22px 20px;
 }
@@ -345,9 +346,17 @@ a:hover {
   padding: 12px 0;
 }
 
-.clause-rank.r1 { background: var(--navy); }
-.clause-rank.r2 { background: #5a6b8c; }
-.clause-rank.r3 { background: #8b96ab; }
+.clause-rank.r1 {
+  background: var(--navy);
+}
+
+.clause-rank.r2 {
+  background: #5a6b8c;
+}
+
+.clause-rank.r3 {
+  background: #8b96ab;
+}
 
 .clause-rank .num {
   font-family: var(--mono);
@@ -382,12 +391,116 @@ a:hover {
   font-weight: 700;
 }
 
-.clause-content {
+/* 문단번호 칩 — 회계사가 인용에 쓰는 조항 번호를 카드 머리로 꺼낸다. */
+.para-chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 5px;
+}
+
+.para-chip {
+  font-family: var(--mono);
+  font-size: 10.5px;
+  padding: 1px 7px;
+  background: var(--paper-3);
+  border: 1px solid var(--line-2);
+  color: var(--navy);
+  border-radius: 2px;
+  white-space: nowrap;
+}
+
+/* 접힘 발췌 — 첫 문단을 최대 3줄까지만 보여준다(줄 수 초과분은 말줄임). */
+.clause-excerpt {
   margin: 0;
   font-size: 13px;
   line-height: 1.7;
   color: #374151;
-  white-space: pre-wrap;
+  display: -webkit-box;
+  -webkit-line-clamp: 3;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.clause-excerpt.is-table-note {
+  color: var(--mute);
+}
+
+.clause-expand {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  align-items: flex-start;
+}
+
+.more-btn {
+  font-family: var(--mono);
+  font-size: 10.5px;
+  padding: 2px 9px 2px 0;
+  background: none;
+  border: none;
+  color: var(--gold);
+  cursor: pointer;
+}
+
+.more-btn:hover {
+  text-decoration: underline;
+}
+
+/* 마크다운 본문 — 편집기호(####·**·|)를 해석해 소제목·굵게·표로 보여준다. */
+.md-content {
+  font-size: 13px;
+  line-height: 1.7;
+  color: #374151;
+  min-width: 0;
+}
+
+.md-content> :first-child {
+  margin-top: 0;
+}
+
+.md-content> :last-child {
+  margin-bottom: 0;
+}
+
+.md-content h1,
+.md-content h2,
+.md-content h3,
+.md-content h4,
+.md-content h5,
+.md-content h6 {
+  /* 조항 소제목(#### 6.13 등)은 본문보다 살짝 작은 네이비 모노 제목으로 — 칩과 시각적으로 이어진다. */
+  font-size: 12.5px;
+  font-family: var(--mono);
+  color: var(--navy);
+  margin: 12px 0 4px;
+}
+
+.md-content p {
+  margin: 4px 0;
+}
+
+.md-content table {
+  border-collapse: collapse;
+  margin: 8px 0;
+  font-size: 12px;
+  display: block;
+  overflow-x: auto;
+  /* 넓은 표가 카드 폭을 뚫지 않게 표 스스로 가로 스크롤한다 */
+  max-width: 100%;
+}
+
+.md-content th,
+.md-content td {
+  border: 1px solid var(--line-2);
+  padding: 4px 9px;
+  text-align: left;
+  vertical-align: top;
+}
+
+.md-content th {
+  background: var(--paper-3);
+  color: var(--navy);
+  font-weight: 700;
 }
 
 .page-btn {
@@ -475,7 +588,7 @@ details.cite-card .cite-content {
   font-size: 12.5px;
   line-height: 1.7;
   color: #4b5563;
-  white-space: pre-wrap;
+  /* 본문은 마크다운 렌더(md-content)라 pre-wrap을 쓰지 않는다 — 원시 줄바꿈 보존이 표·목록 렌더와 충돌한다. */
 }
 
 .muted {
@@ -584,7 +697,9 @@ details.cite-card .cite-content {
 }
 
 @keyframes spin {
-  to { transform: rotate(360deg); }
+  to {
+    transform: rotate(360deg);
+  }
 }
 
 @media (prefers-reduced-motion: reduce) {
@@ -751,15 +866,18 @@ details.cite-card .cite-content {
 }
 
 @media (max-width: 860px) {
+
   /* 기본 .sidebar 규칙보다 뒤에 있어야 display: flex를 이긴다(동일 특이도). */
   .sidebar {
     display: none;
   }
+
   .transcript,
   .composer-wrap {
     padding-left: 20px;
     padding-right: 20px;
   }
+
   .main-header {
     padding: 14px 20px;
   }
@@ -811,7 +929,8 @@ details.cite-card .cite-content {
   display: flex;
   justify-content: space-between;
   align-items: center;
-  flex-wrap: wrap; /* 좁은 폭에서 내비게이션이 다음 줄로 내려가되 버튼 글자는 깨지지 않게 */
+  flex-wrap: wrap;
+  /* 좁은 폭에서 내비게이션이 다음 줄로 내려가되 버튼 글자는 깨지지 않게 */
   gap: 8px 1rem;
   padding: 12px 16px;
   border-bottom: 2px solid var(--navy);

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -298,13 +298,6 @@ a:hover {
   font-variant-numeric: tabular-nums;
 }
 
-.section-head {
-  display: flex;
-  align-items: baseline;
-  justify-content: space-between;
-  gap: 12px;
-}
-
 .section-title {
   margin: 0;
   font-family: var(--serif);
@@ -312,86 +305,7 @@ a:hover {
   color: var(--navy);
 }
 
-.section-title .accent {
-  color: var(--gold);
-}
-
-.section-note {
-  font-size: 11.5px;
-  color: var(--mute);
-}
-
-/* 조항 카드 — 랭크 컬럼 + 본문 */
-
-.clause-list {
-  display: flex;
-  flex-direction: column;
-  gap: 10px;
-}
-
-.clause-card {
-  display: grid;
-  grid-template-columns: 52px 1fr;
-  border: 1px solid var(--line);
-  background: #fff;
-}
-
-.clause-rank {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  justify-content: center;
-  gap: 4px;
-  color: #fff;
-  padding: 12px 0;
-}
-
-.clause-rank.r1 {
-  background: var(--navy);
-}
-
-.clause-rank.r2 {
-  background: #5a6b8c;
-}
-
-.clause-rank.r3 {
-  background: #8b96ab;
-}
-
-.clause-rank .num {
-  font-family: var(--mono);
-  font-size: 16px;
-  font-weight: 600;
-}
-
-.clause-rank .score {
-  font-family: var(--mono);
-  font-size: 10px;
-  opacity: 0.75;
-}
-
-.clause-body {
-  padding: 13px 18px;
-  display: flex;
-  flex-direction: column;
-  gap: 7px;
-  min-width: 0;
-}
-
-.clause-title-row {
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  flex-wrap: wrap;
-}
-
-.clause-title {
-  font-size: 13px;
-  color: var(--navy);
-  font-weight: 700;
-}
-
-/* 문단번호 칩 — 회계사가 인용에 쓰는 조항 번호를 카드 머리로 꺼낸다. */
+/* 문단번호 칩 — 회계사가 인용에 쓰는 조항 번호를 사이드 패널에 노출한다. */
 .para-chips {
   display: flex;
   flex-wrap: wrap;
@@ -407,43 +321,6 @@ a:hover {
   color: var(--navy);
   border-radius: 2px;
   white-space: nowrap;
-}
-
-/* 접힘 발췌 — 첫 문단을 최대 3줄까지만 보여준다(줄 수 초과분은 말줄임). */
-.clause-excerpt {
-  margin: 0;
-  font-size: 13px;
-  line-height: 1.7;
-  color: #374151;
-  display: -webkit-box;
-  -webkit-line-clamp: 3;
-  -webkit-box-orient: vertical;
-  overflow: hidden;
-}
-
-.clause-excerpt.is-table-note {
-  color: var(--mute);
-}
-
-.clause-expand {
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-  align-items: flex-start;
-}
-
-.more-btn {
-  font-family: var(--mono);
-  font-size: 10.5px;
-  padding: 2px 9px 2px 0;
-  background: none;
-  border: none;
-  color: var(--gold);
-  cursor: pointer;
-}
-
-.more-btn:hover {
-  text-decoration: underline;
 }
 
 /* 마크다운 본문 — 편집기호(####·**·|)를 해석해 소제목·굵게·표로 보여준다. */
@@ -503,21 +380,6 @@ a:hover {
   font-weight: 700;
 }
 
-.page-btn {
-  font-family: var(--mono);
-  font-size: 10.5px;
-  padding: 2px 9px;
-  background: #fff;
-  border: 1px solid var(--navy);
-  color: var(--navy);
-  border-radius: 2px;
-}
-
-.page-btn:hover {
-  background: var(--navy);
-  color: #fff;
-}
-
 /* 답변 */
 
 .answer-block {
@@ -536,64 +398,27 @@ a:hover {
   white-space: pre-wrap;
 }
 
-/* 인용 */
-
-.cite-list {
-  display: flex;
-  flex-direction: column;
-  gap: 6px;
-}
-
-details.cite-card {
-  border: 1px solid var(--line);
-  background: var(--paper-2);
-}
-
-details.cite-card summary {
-  cursor: pointer;
-  padding: 9px 14px;
-  font-size: 12px;
-  color: #4b5563;
-  display: flex;
-  align-items: center;
-  gap: 10px;
-  flex-wrap: wrap;
-  list-style: none;
-}
-
-details.cite-card summary::before {
-  content: "›";
+/* 답변 속 조항 번호 — 인용 마커([1])를 치환한 클릭 가능한 근거 링크. */
+.answer-ref {
   font-family: var(--mono);
+  font-size: 12.5px;
+  padding: 0 2px;
+  background: none;
+  border: none;
   color: var(--gold);
-  transition: transform 0.15s;
+  font-weight: 600;
+  cursor: pointer;
 }
 
-details.cite-card[open] summary::before {
-  transform: rotate(90deg);
-}
-
-details.cite-card summary strong {
+.answer-ref:hover {
+  text-decoration: underline;
   color: var(--navy);
 }
 
-details.cite-card summary .rel {
-  font-family: var(--mono);
-  font-size: 10.5px;
-  color: var(--gold);
-}
-
-details.cite-card .cite-content {
+.answer-refs-note {
   margin: 0;
-  padding: 0 14px 12px 30px;
-  font-size: 12.5px;
-  line-height: 1.7;
-  color: #4b5563;
-  /* 본문은 마크다운 렌더(md-content)라 pre-wrap을 쓰지 않는다 — 원시 줄바꿈 보존이 표·목록 렌더와 충돌한다. */
-}
-
-.muted {
+  font-size: 11px;
   color: var(--mute);
-  font-size: 12.5px;
 }
 
 /* ── 상태 카드: HIL / 로딩 / 에러 / 공지 ─────────────── */
@@ -906,23 +731,47 @@ details.cite-card .cite-content {
 
 /* ── PDF 뷰어 모달 ───────────────────────────────────── */
 
-.viewer-overlay {
+/* 인용 사이드 패널 — 답변 속 조항 번호를 누르면 오른쪽에 열리는 드로어.
+   답변을 가리지 않도록 오버레이(배경 어둡게) 없이 겹쳐 띄운다. */
+.side-panel {
   position: fixed;
-  inset: 0;
-  background: rgba(22, 41, 77, 0.55);
+  top: 0;
+  right: 0;
+  bottom: 0;
+  width: min(560px, 92vw);
+  background: var(--paper);
+  border-left: 1px solid var(--line-2);
+  box-shadow: -12px 0 32px rgba(22, 41, 77, 0.14);
   display: flex;
-  align-items: center;
-  justify-content: center;
-  padding: 1.5rem;
+  flex-direction: column;
   z-index: 10;
 }
 
-.viewer-panel {
-  background: var(--paper);
-  width: min(960px, 100%);
-  height: min(90vh, 100%);
+.side-panel-meta {
   display: flex;
-  flex-direction: column;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+  padding: 10px 16px 0;
+}
+
+.side-panel-meta .rel {
+  font-family: var(--mono);
+  font-size: 10.5px;
+  color: var(--gold);
+}
+
+/* 인용 본문(마크다운) — PDF 미배치 시 본문이 근거의 전부이므로 패널 폭에 맞춰 스크롤한다. */
+.side-panel-source {
+  overflow-y: auto;
+  min-height: 0;
+}
+
+.side-panel-source summary {
+  cursor: pointer;
+  font-size: 12px;
+  color: var(--mute);
+  padding: 4px 0;
 }
 
 .viewer-header {

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -64,6 +64,11 @@ a:hover {
   min-height: 100vh;
 }
 
+/* 인용 사이드 패널이 열리면 3번째 컬럼을 내주고 본문(1fr)이 줄어든다 — 겹침으로 본문을 가리지 않기 위해. */
+.app.with-panel {
+  grid-template-columns: 250px 1fr min(480px, 38vw);
+}
+
 @media (max-width: 860px) {
   .app {
     grid-template-columns: 1fr;
@@ -415,12 +420,6 @@ a:hover {
   color: var(--navy);
 }
 
-.answer-refs-note {
-  margin: 0;
-  font-size: 11px;
-  color: var(--mute);
-}
-
 /* ── 상태 카드: HIL / 로딩 / 에러 / 공지 ─────────────── */
 
 .hil-card {
@@ -734,17 +733,33 @@ a:hover {
 /* 인용 사이드 패널 — 답변 속 조항 번호를 누르면 오른쪽에 열리는 드로어.
    답변을 가리지 않도록 오버레이(배경 어둡게) 없이 겹쳐 띄운다. */
 .side-panel {
-  position: fixed;
+  /* 그리드 3번째 컬럼(.app.with-panel)에 참여한다 — 겹쳐 띄우면 본문 글자를 가리므로, 열리면 본문 컬럼(1fr)이 스스로 줄어들어 답변이 계속 읽히게 한다. */
+  position: sticky;
   top: 0;
-  right: 0;
-  bottom: 0;
-  width: min(560px, 92vw);
+  height: 100vh;
   background: var(--paper);
   border-left: 1px solid var(--line-2);
-  box-shadow: -12px 0 32px rgba(22, 41, 77, 0.14);
+  box-shadow: -12px 0 32px rgba(22, 41, 77, 0.1);
   display: flex;
   flex-direction: column;
-  z-index: 10;
+  min-width: 0;
+}
+
+/* 좁은 화면에서는 줄일 본문 폭이 없으므로 예외적으로 겹침(드로어)으로 되돌린다. */
+@media (max-width: 1100px) {
+  .app.with-panel {
+    grid-template-columns: 250px 1fr;
+  }
+
+  .side-panel {
+    position: fixed;
+    top: 0;
+    right: 0;
+    bottom: 0;
+    height: auto;
+    width: min(560px, 92vw);
+    z-index: 10;
+  }
 }
 
 .side-panel-meta {

--- a/src/api/schemas.py
+++ b/src/api/schemas.py
@@ -19,6 +19,7 @@ from pydantic import BaseModel
 
 from src.agent.interrupts import extract_interrupt_payload, is_interrupt
 from src.ui.clauses import build_clause_rows
+from src.utils.clause_paras import chunk_paras
 
 
 class ClauseOut(BaseModel):
@@ -32,6 +33,7 @@ class ClauseOut(BaseModel):
     document_id: str = ""          # 뷰어가 GET /documents/{document_id}/pdf를 여는 데 사용(#196)
     page_start: int | None = None  # 원본 PDF 페이지 범위(#196) — 미백필/미매칭이면 None(뷰어 버튼 미표시)
     page_end: int | None = None
+    paras: list[str] = []          # 문단번호 칩(#260) — 공용 규칙(clause_paras) 추출, 원형 보존
 
 
 class CitationOut(BaseModel):
@@ -43,6 +45,9 @@ class CitationOut(BaseModel):
     relevance_score: float
     page_start: int | None = None  # chunk_id로 reranked_chunks metadata를 조회해 결합(#196)
     page_end: int | None = None
+    # 문단번호 칩 — 검색 조항 목록과 같은 규칙으로 뽑아야 화면의 두 목록에서 같은 조항이 같은 모양으로 보인다.
+    # Citation 스키마 불변 원칙에 따라 여기서 파생한다.
+    paras: list[str] = []
 
 
 class InterruptOption(BaseModel):
@@ -138,6 +143,7 @@ def to_api_response(result: dict) -> WorkflowResponse:
                 relevance_score=c.relevance_score,
                 page_start=pages_by_chunk.get(c.chunk_id, (None, None))[0],
                 page_end=pages_by_chunk.get(c.chunk_id, (None, None))[1],
+                paras=chunk_paras(c.content, c.chunk_id),
             )
             for c in response.citations
         ],

--- a/src/api/server.py
+++ b/src/api/server.py
@@ -203,7 +203,14 @@ def document_pdf(
     pdf_path = resolve_pdf_path(document_id, PDF_DIR)
     if pdf_path is None:
         raise HTTPException(status_code=404, detail=f"no pdf for document_id: {document_id}")
-    return FileResponse(pdf_path, media_type="application/pdf", filename=pdf_path.name)
+    # filename을 넘기면 Starlette이 표지를 attachment로 기본 설정해 뷰어 iframe이 PDF를 표시하지 못한다
+    # inline으로 명시해 화면 표시를 되살린다
+    return FileResponse(
+        pdf_path,
+        media_type="application/pdf",
+        filename=pdf_path.name,
+        content_disposition_type="inline",
+    )
 
 
 @app.get("/favicon.svg")

--- a/src/ingest/ontology/chunker.py
+++ b/src/ingest/ontology/chunker.py
@@ -24,6 +24,7 @@ from collections.abc import Callable
 
 from src.ingest.ontology.models import OntologyGraph
 from src.models.schemas import ChunkMetadata, RetrievedChunk
+from src.utils.clause_paras import clause_header_re
 from src.utils.config import CHUNK_MAX_TOKENS
 from src.clients.embedding import count_tokens
 from src.utils.exception import OntologyParsingError
@@ -35,8 +36,10 @@ logger = get_logger(__name__)
 _SENTENCE_RE = re.compile(r"(?<=[.。!?！？])\s+")
 
 # 조항 헤더 경계 분할용 — "#### 21.8", "#### 2.6.5", "#### 21.5의2"를 줄 시작에서 잡는다.
-# 채점기(tests/utils/benchmark_metrics._CHUNK_PARA_RE)와 동일 본체라 분할 경계와 채점 기준이 일치한다.
-_CLAUSE_HEADER_RE = re.compile(r"^####\s+\d+\.\d+(?:\.\d+)?(?:의\d+)?", re.MULTILINE)
+# 공용 규칙(clause_paras)에서 생성하되 현행 의미(H4·숫자 전용)를 고정한다 — 접두(실·결·소)나
+# H5까지 경계로 넓히면 다음 재적재부터 청크 구성이 달라져 검색 회귀 검증과 벤치마크 플로어
+# 재시드가 필요해진다. 경계 확장은 별도 이슈에서 A/B 실측으로 판단한다.
+_CLAUSE_HEADER_RE = clause_header_re(levels=(4, 4), prefixes=())
 
 
 def _greedy_pack(units: list[str], sep: str, max_tokens: int, count: Callable[[str], int]) -> list[str]:

--- a/src/ui/clauses.py
+++ b/src/ui/clauses.py
@@ -5,9 +5,10 @@ NFR-002: 조항 검색이 1순위, LLM 답변은 참고용 — app.py는 이 모
 """
 from __future__ import annotations
 
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 
 from src.models.schemas import RerankingResult
+from src.utils.clause_paras import chunk_paras
 
 DEFAULT_TOP_N = 5
 
@@ -24,6 +25,10 @@ class ClauseRow:
     document_id: str = ""          # 원문 문서 식별자(chunk.document_id) — 뷰어의 PDF 서빙 경로에 사용(#196)
     page_start: int | None = None  # 원본 PDF 페이지 범위(#196 백필 metadata) — 미백필/미매칭이면 None
     page_end: int | None = None
+    # 문단번호 목록
+    # 공용 규칙이 content 헤더 ∪ chunk_id에서 원형 그대로(가지번호 유지) 뽑는다.
+    # 용어 정의처럼 번호가 본래 없는 청크는 빈 목록.
+    paras: list[str] = field(default_factory=list)
 
 
 def build_clause_rows(
@@ -56,6 +61,7 @@ def build_clause_rows(
                 document_id=chunk.document_id,
                 page_start=extra.get("page_start"),
                 page_end=extra.get("page_end"),
+                paras=chunk_paras(chunk.content, chunk.chunk_id),
             )
         )
     return rows

--- a/src/utils/clause_paras.py
+++ b/src/utils/clause_paras.py
@@ -62,18 +62,24 @@ def clause_header_re(
     )
 
 
-# 추출 정본 정규식. 줄 시작 앵커라 본문 중간 언급("본문에 결21.15를 인용")은 잡지 않는다.
+# 추출 정본 정규식 — 두 표기를 잡는다:
+#   1) 헤딩:          "#### 실2.24"        (H3~H5, 문단 헤더의 정규 표기)
+#   2) 줄 시작 굵게:  "**실19.1** 이 장…"  (ch19 실무지침 4건이 헤딩 대신 쓰는 표기 — 운영 DB 실측)
+# 둘 다 줄 시작 앵커라 본문 중간 언급("본문에 결21.15를 인용")은 잡지 않고, 굵은 쪽은 **…** 안이 번호 토큰 전체와 일치할 때만 라벨로 본다(**20X2. 9. 1.(…)** 미매칭).
 CONTENT_PARA_RE = clause_header_re()
+_BOLD_PARA_RE = re.compile(rf"^\*\*({TOKEN_PATTERN})\*\*", re.MULTILINE)
 
 
 def content_paras(content: str) -> list[str]:
-    """본문 헤더에서 문단번호를 등장 순서대로, 중복 없이, 원형 그대로 뽑는다.
+    """본문에서 문단번호를 등장 순서대로, 중복 없이, 원형 그대로 뽑는다.
 
-    예: "#### 6.13\\n…\\n#### 실2.24\\n…" → ["6.13", "실2.24"].
+    예: "#### 6.13\\n…\\n**실19.1** …" → ["6.13", "실19.1"].
     """
+    matches = [(m.start(), m.group(1)) for m in CONTENT_PARA_RE.finditer(content)]
+    matches += [(m.start(), m.group(1)) for m in _BOLD_PARA_RE.finditer(content)]
     seen: set[str] = set()
     out: list[str] = []
-    for p in CONTENT_PARA_RE.findall(content):
+    for _, p in sorted(matches):
         if p not in seen:
             seen.add(p)
             out.append(p)

--- a/src/utils/clause_paras.py
+++ b/src/utils/clause_paras.py
@@ -1,0 +1,110 @@
+"""
+조항 문단번호 추출 공용 모듈 — 채점기·chunker·UI가 함께 쓰는 단일 정본.
+
+[배경] 기준서 청크 본문은 마크다운이고, 조항 문단은 "#### 6.13"처럼 헤딩으로 표시된다.
+문단에는 일반 번호 외에 한글 접두가 붙는 종류가 있다. 실(실무지침), 결(결론도출근거), 소(중소기업 특례). 
+또 온톨로지 노드가 조항 하나인 청크는 번호가 본문에 없고 chunk_id 꼬리에만 있다(예: "gaap-ch2-실2.11")
+2026-07-25 운영 DB 전수조사(1,507청크)
+실측: 접두 헤더 실 415·결 107·소 6건, 번호가 chunk_id에만 있는 청크 435건.
+
+[목적] 문단번호를 뽑는 규칙을 이 모듈 한 곳에 두어, 벤치마크 채점기·조항 chunker·화면(조항 카드 칩)이 같은 규칙을 소비하게 한다.
+규칙이 두 벌로 복사되면 수정이 한쪽만 반영돼 "채점은 맞는데 화면은 틀린" 상태가 구조적으로 생긴다.
+
+[제약] 추출 결과는 원형 보존이다. "6.13의2"는 "6.13의2"로 돌려준다. 가지번호를
+"6.13"으로 합치는 정규화는 통계를 내는 채점기의 요구이고, 화면은 원형을 그대로 보여야 회계사가 그 조항을 찾을 수 있어 요구가 반대다.
+정규화는 각 소비자가 한다.
+접두는 명시 allowlist만 허용한다.
+열린 한글 패턴([가-힣]+)을 쓰면 "사례"·"부록" 같은 비조항 제목이 오탐으로 섞인다.
+"""
+from __future__ import annotations
+
+import re
+from collections.abc import Sequence
+
+# 접두 allowlist. 운영 코퍼스 전수조사에서 실재가 확인된 세 종류만 허용한다.
+PARA_PREFIXES: tuple[str, ...] = ("실", "결", "소")
+
+# 문단번호의 구성 조각. 예: "6.13" / "2.6.5" / "6.13의2" → NUM_CORE + BRANCH.
+# 채점기의 범위 표기("15.15조~15.16조") 파싱처럼 가지번호 없는 꼴이 필요한 소비자가 있어 본체와 가지를 분리해 둔다.
+NUM_CORE_PATTERN = r"\d+\.\d+(?:\.\d+)?"
+BRANCH_PATTERN = r"(?:의\d+)?"
+PREFIX_PATTERN = rf"(?:{'|'.join(PARA_PREFIXES)})"
+
+# 문단번호 토큰 한 개(접두 선택 + 본체 + 가지). gold 라벨의 "실2.11조"에서 "실2.11"을 잡는 데 쓴다
+# 접두를 버리면 같은 장의 일반 문단 2.11과 구분되지 않는다.
+TOKEN_PATTERN = rf"{PREFIX_PATTERN}?{NUM_CORE_PATTERN}{BRANCH_PATTERN}"
+PARA_TOKEN_RE = re.compile(TOKEN_PATTERN)
+
+_TOKEN_FULL_RE = re.compile(TOKEN_PATTERN)
+
+
+def clause_header_re(
+    *,
+    levels: tuple[int, int] = (3, 5),
+    prefixes: Sequence[str] = PARA_PREFIXES,
+) -> re.Pattern[str]:
+    """
+    문단 헤더 정규식을 소비자별 변형으로 생성한다(사본 0의 실현 수단).
+    levels는 허용 헤딩 레벨 범위다. 추출 기본값 (3, 5)는 실물 기준이다.
+    청크 정본은 H4가 정규이고 H5는 ch12의 12.21~12.26 6건이 실재하며,
+    H3은 이슈 #255가 지목한 소스 마크다운 표기라 빌더가 레벨을 바꿔도 깨지지 않게 포함한다.
+    H6은 각주·미주 제목이라 제외한다.
+
+    chunker는 분할 경계용으로 levels=(4, 4)·prefixes=()를 넘겨 현행 의미를 고정한다 —
+    경계를 넓히면 다음 재적재부터 청크 구성이 달라져 검색 회귀 검증과 벤치마크 플로어
+    재시드가 필요해지기 때문이다. 경계 확장은 별도 이슈에서 A/B로 판단한다.
+    """
+    lo, hi = levels
+    hashes = f"#{{{lo}}}" if lo == hi else f"#{{{lo},{hi}}}"
+    prefix = f"(?:{'|'.join(prefixes)})?" if prefixes else ""
+    return re.compile(
+        rf"^{hashes}\s+({prefix}{NUM_CORE_PATTERN}{BRANCH_PATTERN})", re.MULTILINE
+    )
+
+
+# 추출 정본 정규식. 줄 시작 앵커라 본문 중간 언급("본문에 결21.15를 인용")은 잡지 않는다.
+CONTENT_PARA_RE = clause_header_re()
+
+
+def content_paras(content: str) -> list[str]:
+    """본문 헤더에서 문단번호를 등장 순서대로, 중복 없이, 원형 그대로 뽑는다.
+
+    예: "#### 6.13\\n…\\n#### 실2.24\\n…" → ["6.13", "실2.24"].
+    """
+    seen: set[str] = set()
+    out: list[str] = []
+    for p in CONTENT_PARA_RE.findall(content):
+        if p not in seen:
+            seen.add(p)
+            out.append(p)
+    return out
+
+
+def node_id_para(chunk_id: str) -> str | None:
+    """
+    chunk_id 꼬리 토큰이 문단번호면 돌려준다. 예: "gaap-ch2-실2.11" → "실2.11".
+
+    단일 조항 노드는 온톨로지 빌더가 조항 번호를 노드 id로 쓰고 본문에는 헤더를 남기지 않으므로, 여기서 못 읽으면 그 조항은 채점·칩 표시 어디에서도 번호가 없는 것이 된다.
+    토큰 상한 분할 뒷조각의 "-N" 접미사(예: "…-실2.11-2")는 벗겨내고 판정한다.
+    """
+    if not chunk_id:
+        return None
+    segments = chunk_id.split("-")
+    if len(segments) >= 2 and segments[-1].isdigit():  # 분할 뒷조각 접미사(-2, -3 …)
+        segments = segments[:-1]
+    tail = segments[-1]
+    return tail if _TOKEN_FULL_RE.fullmatch(tail) else None
+
+
+def chunk_paras(content: str, chunk_id: str = "") -> list[str]:
+    """
+    청크 한 건의 문단번호 = content 헤더 ∪ chunk_id 꼬리 토큰(중복 제거).
+
+    다발 청크는 content 헤더에서, 단일 조항 청크는 chunk_id에서 번호가 나온다.
+    id 토큰은 대개 content에 없을 때만 존재하므로 목록 끝에 보탠다.
+    """
+    paras = content_paras(content)
+    id_para = node_id_para(chunk_id)
+    if id_para and id_para not in paras:
+        paras.append(id_para)
+    return paras

--- a/tests/unit/api/test_schemas.py
+++ b/tests/unit/api/test_schemas.py
@@ -93,6 +93,36 @@ class TestDoneResponse:
         c = res.citations[0]
         assert (c.document_id, c.chunk_id, c.relevance_score) == ("gaap-ch7", "c1", 0.83)
 
+    def test_clause_and_citation_paras_exposed(self):
+        """
+        clauses[]·citations[] 모두 문단번호 목록(paras)을 노출한다.
+
+        화면의 두 목록(검색된 조항·답변 인용)이 같은 조항을 다른 모양으로 보여주지 않도록, 번호 추출은 서버 공용 규칙 한 곳에서 하고 프론트는 소비만 한다.
+        """
+        result = _done_result(
+            reranked_chunks=[
+                _rr("gaap-ch6-s1-최초인식", 0.9, content="#### 6.13\n...\n#### 6.14\n..."),
+                _rr("gaap-ch2-실2.11", 0.8, content="차익, 차손 등은 총액으로..."),
+            ],
+            final_response=FinalResponse(
+                answer="…",
+                citations=[
+                    Citation(
+                        document_id="gaap-ch2",
+                        chunk_id="gaap-ch2-실2.11",
+                        content="차익, 차손 등은 총액으로...",
+                        relevance_score=0.8,
+                    )
+                ],
+                is_answerable=True,
+                confidence_score=0.9,
+            ),
+        )
+        res = to_api_response(result)
+        assert res.clauses[0].paras == ["6.13", "6.14"]
+        assert res.clauses[1].paras == ["실2.11"]
+        assert res.citations[0].paras == ["실2.11"]
+
     def test_empty_reranked_chunks_yield_empty_clauses(self):
         """폴백·조기종료 결과처럼 reranked_chunks가 비어도 안전하게 빈 리스트"""
         res = to_api_response(_done_result(reranked_chunks=[]))

--- a/tests/unit/api/test_server.py
+++ b/tests/unit/api/test_server.py
@@ -233,6 +233,34 @@ class TestDocumentPdf:
         monkeypatch.setattr("src.api.server.PDF_DIR", str(tmp_path))
         assert client.get("/documents/gaap-ch10/pdf").status_code == 404
 
+    def test_disposition_is_inline_with_filename(self, client, monkeypatch, tmp_path):
+        """
+        표지(Content-Disposition: 브라우저에게 파일 처리 방식을 알리는 응답 헤더)가 inline이어야 뷰어 iframe에 PDF가 화면으로 뜬다.
+
+        attachment면 iframe이 빈 화면이 되거나 파일이 내려받아진다. 
+        파일명은 사용자가 직접 저장할 때 남도록 헤더에 유지한다.
+        """
+        (tmp_path / "gaap-ch10.pdf").write_bytes(b"%PDF-1.4 test")
+        monkeypatch.setattr("src.api.server.PDF_DIR", str(tmp_path))
+        r = client.get("/documents/gaap-ch10/pdf")
+        disposition = r.headers["content-disposition"]
+        assert disposition.startswith("inline")
+        assert "filename" in disposition
+
+    def test_disposition_stays_inline_for_korean_filename(self, client, monkeypatch, tmp_path):
+        """
+        실제 기준서 파일명은 한글이라 표지가 RFC 5987 표기(filename*=UTF-8''…)로 나간다
+        그 경로에서도 inline이 유지되는지 고정한다.
+
+        영문 파일명으로만 시험하면 실제 운영 파일에서만 깨지는 상황이 남는다.
+        전체 문자열 단언은 인코딩 표기 차이로 깨지므로 표지 타입만 단언한다.
+        """
+        (tmp_path / "제6장 금융자산·금융부채.pdf").write_bytes(b"%PDF-1.4 test")
+        monkeypatch.setattr("src.api.server.PDF_DIR", str(tmp_path))
+        r = client.get("/documents/gaap-ch6/pdf")
+        assert r.status_code == 200
+        assert r.headers["content-disposition"].startswith("inline")
+
     def test_head_is_supported_for_availability_check(self, client, monkeypatch, tmp_path):
         """React 뷰어(checkPdfAvailable)는 HEAD로 제공 여부를 묻는다.
 

--- a/tests/unit/ui/test_clauses.py
+++ b/tests/unit/ui/test_clauses.py
@@ -64,6 +64,28 @@ def test_empty_and_nonpositive_top_n():
     assert build_clause_rows([_rr("a", 1.0)], top_n=0) == []
 
 
+def test_paras_from_content_headers_and_chunk_id():
+    """
+    문단번호 칩 — 공용 규칙으로 content 헤더 ∪ chunk_id에서 채운다.
+
+    다발 청크는 본문 헤더에서, 단일 조항 청크(번호가 id에만 있음)는 chunk_id에서
+    번호가 나오고, 용어 정의처럼 번호가 본래 없는 청크는 빈 목록이다.
+    """
+    bundle = _rr("gaap-ch6-s1-최초인식", 0.9, content="#### 6.13\n금융자산은...\n#### 6.14\n...")
+    single = _rr("gaap-ch2-실2.11", 0.8, content="차익, 차손 등은 총액으로 표시하지만...")
+    plain = _rr("gaap-ch10-용어의_정의-원가", 0.7, content="자산을 취득하기 위하여...")
+    rows = build_clause_rows([bundle, single, plain])
+    assert rows[0].paras == ["6.13", "6.14"]
+    assert rows[1].paras == ["실2.11"]
+    assert rows[2].paras == []
+
+
+def test_paras_preserve_branch_suffix_verbatim():
+    """가지번호(6.13의2)는 원형 그대로 — 합쳐서(→6.13) 보여주면 회계사가 조항을 못 찾는다."""
+    rows = build_clause_rows([_rr("a", 0.9, content="#### 6.13의2\n내재파생...")])
+    assert rows[0].paras == ["6.13의2"]
+
+
 def test_page_range_and_document_id_from_metadata():
     """metadata extra의 page_start/page_end와 chunk.document_id를 노출한다 — #196 뷰어가 소비."""
     rr = RerankingResult(

--- a/tests/unit/utils/test_clause_normalization.py
+++ b/tests/unit/utils/test_clause_normalization.py
@@ -118,6 +118,13 @@ class TestExtractChunkParas:
         """'결21.15'·'실15.5'처럼 #### 헤더가 아닌 인라인 표기는 추출하지 않는다"""
         assert extract_chunk_paras("본문에 결21.15 또는 실15.5를 인용") == set()
 
+    def test_h5_header_scoring_preserved(self):
+        """
+        ch12의 '##### 12.21~12.26'(실물 6건)은 현행 비앵커 정규식이 잡던 형태
+        새 규칙이 놓치면 채점 회귀가 되므로 고정한다.
+        """
+        assert extract_chunk_paras("##### 12.21\n인식원칙의 예외...") == {"12.21"}
+
 
 @pytest.mark.unit
 class TestParasMatch:
@@ -173,3 +180,69 @@ class TestRankHit:
         first, covered = rank_hit(["#### 1.1\n..."], set(), "exact")
         assert first is None
         assert covered == set()
+
+
+@pytest.mark.unit
+class TestPrefixedParaScoring:
+    """#255: 실·결·소 접두 문단을 gold·청크 양쪽에서 키의 일부로 보존한다.
+
+    운영 DB 실측(2026-07-25, 1,507청크): 실(실무지침) 415·결(결론도출근거) 107·
+    소(중소기업 특례) 6건의 H4 헤더가 실재한다. 접두를 벗기면 같은 장의 일반 문단과
+    구분되지 않아(실2.11 → 2.11) 오탐 매칭이 생긴다.
+    """
+
+    def test_gold_preserves_practice_prefix(self):
+        clauses = parse_gold_clauses(["일반기업회계기준 제2장 실2.11조"])
+        assert clauses[0].chapter == "2"
+        assert clauses[0].paras == {"실2.11"}
+
+    def test_gold_conclusion_prefix_and_plain_mixed(self):
+        clauses = parse_gold_clauses(["일반기업회계기준 제21장 21.13조, 결21.6조, 결21.7조"])
+        assert clauses[0].paras == {"21.13", "결21.6", "결21.7"}
+
+    def test_gold_prefixed_range_expansion(self):
+        """'실2.46조~실2.47조' 범위는 접두를 유지한 채 끝점 포함으로 펼친다."""
+        clauses = parse_gold_clauses(["일반기업회계기준 제2장 실2.46조~실2.47조"])
+        assert clauses[0].paras == {"실2.46", "실2.47"}
+
+    def test_prefixed_and_plain_do_not_cross_match(self):
+        """실2.11 ≠ 2.11 — exact·prefix 어느 모드에서도 서로 매칭되지 않는다."""
+        assert _paras_match({"실2.11"}, {"2.11"}, "exact") == set()
+        assert _paras_match({"실2.11"}, {"2.11"}, "prefix") == set()
+        assert _paras_match({"2.11"}, {"실2.11"}, "prefix") == set()
+
+    def test_chunk_header_with_prefix_matches_gold(self):
+        gold = gold_para_set(parse_gold_clauses(["일반기업회계기준 제12장 실12.1조"]))
+        chunk = extract_chunk_paras("#### 실12.1\n주식기준보상거래에서...")
+        assert _paras_match(gold, chunk, "exact") == {"실12.1"}
+
+    def test_normalize_keeps_prefix_strips_branch(self):
+        assert _normalize_para("실21.5의2") == "실21.5"
+
+
+@pytest.mark.unit
+class TestChunkIdUnionScoring:
+    """#255: 추출을 content 헤더 ∪ chunk_id 유니언으로 확장한다.
+
+    운영 DB 실측: 단일 조항 노드 435건은 번호가 content에 없고 chunk_id에만 있다
+    (예: gaap-ch2-실2.11). content 정규식만 고치면 이들은 여전히 영구 miss다.
+    """
+
+    def test_extract_falls_back_to_chunk_id(self):
+        """TEST-K-GAAP-011 실물 재현: 실2.11 청크는 content에 헤더가 전혀 없다."""
+        body = "동일 또는 유사한 거래나 회계사건에서 발생한 차익, 차손 등은 총액으로 표시하지만..."
+        assert extract_chunk_paras(body, "gaap-ch2-실2.11") == {"실2.11"}
+
+    def test_rank_hit_accepts_content_id_pairs(self):
+        items = [
+            ("#### 2.10\n...", "gaap-ch2-회계정책"),
+            ("동일 또는 유사한 거래나 회계사건에서...", "gaap-ch2-실2.11"),
+        ]
+        first, covered = rank_hit(items, {"실2.11"}, "exact")
+        assert first == 2
+        assert covered == {"실2.11"}
+
+    def test_rank_hit_plain_strings_still_work(self):
+        """재현 하니스(scripts/*_replay.py 7종)의 기존 호출 형태(list[str]) 하위호환."""
+        first, _ = rank_hit(["#### 18.4\n..."], {"18.4"}, "exact")
+        assert first == 1

--- a/tests/unit/utils/test_clause_paras.py
+++ b/tests/unit/utils/test_clause_paras.py
@@ -61,6 +61,19 @@ class TestContentParas:
         """allowlist 밖 한글 접두는 미매칭 — 열린 패턴 오탐 차단이 설계 의도다."""
         assert content_paras("#### 부록2.1\n…") == []
 
+    def test_bold_marked_number_recognized(self):
+        """
+        줄 시작 굵게 표기(**실19.1** …)도 문단 라벨이다 — ch19 실무지침 4건
+        (실19.1·실19.5·실19.6·실19.21)은 헤딩·chunk_id 어느 쪽에도 번호가 없어
+        이 표기를 못 읽으면 채점·칩 양쪽에서 영구히 번호 없는 조항이 된다.
+        """
+        assert content_paras("**실19.1** 이 장에서는 부여일을 다음과 같이 정의하고 있다.") == ["실19.1"]
+
+    def test_bold_number_mid_line_or_phrase_ignored(self):
+        """줄 중간의 굵게 언급과 번호가 아닌 굵게 구절(**20X2. 9. 1.(…)**)은 라벨이 아니다."""
+        assert content_paras("본문 중간의 **실19.1** 언급은 라벨이 아니다") == []
+        assert content_paras("**20X2. 9. 1.(분양공사지출에 대한 회계처리)**\n차) 미완성주택") == []
+
     def test_duplicates_removed_order_kept(self):
         assert content_paras("#### 6.13\n…\n#### 6.14\n…\n#### 6.13\n…") == ["6.13", "6.14"]
 

--- a/tests/unit/utils/test_clause_paras.py
+++ b/tests/unit/utils/test_clause_paras.py
@@ -1,0 +1,138 @@
+"""
+조항 문단번호 추출 공용 모듈 단위 테스트
+
+대상: src/utils/clause_paras.py
+  - clause_header_re() : 문단 헤더 정규식 빌더(레벨 범위·접두 allowlist 파라미터)
+  - content_paras()    : 청크 본문의 문단 헤더 → 번호 목록(등장 순서, 원형 보존)
+  - node_id_para()     : chunk_id 꼬리 토큰 → 문단번호 (예: "gaap-ch2-실2.11" → "실2.11")
+  - chunk_paras()      : content ∪ chunk_id 유니언
+
+표본은 2026-07-25 운영 DB(chunks 1,507건·33장) 전수조사에서 실측한 실물 형태를 쓴다.
+접두 allowlist(실=실무지침, 결=결론도출근거, 소=중소기업 특례)와 헤딩 레벨(H4 정규, H5는 ch12의 12.21~12.26 6건)이 그 조사 결과다.
+열린 한글 패턴([가-힣]+)을 쓰지 않는 이유는 "사례"·"부록" 같은 비조항 제목이 오탐으로 섞이는 것을 구조적으로 막기 위해서다.
+"""
+import pytest
+
+from src.utils.clause_paras import (
+    chunk_paras,
+    clause_header_re,
+    content_paras,
+    node_id_para,
+)
+
+
+@pytest.mark.unit
+class TestContentParas:
+    """content_paras() — 본문 헤더에서 문단번호를 등장 순서·원형 그대로 뽑는다"""
+
+    def test_h4_plain_numbers_in_order(self):
+        content = "#### 6.13\n금융자산은 …\n#### 6.14\n| 구분 | 측정기준 |\n#### 6.15\n…"
+        assert content_paras(content) == ["6.13", "6.14", "6.15"]
+
+    def test_branch_suffix_preserved_verbatim(self):
+        """가지번호(의N)는 원형 보존 — 합치기(6.13의2→6.13)는 소비자(채점기)의 몫이다.
+
+        화면은 '6.13의2'를 그대로 보여야 회계사가 그 조항을 찾을 수 있다.
+        """
+        assert content_paras("#### 21.5의2\n…\n#### 11.31의2\n…") == ["21.5의2", "11.31의2"]
+
+    def test_practice_prefix_recognized(self):
+        """실무지침 문단(실N.M) 인식 — #255의 발단. 운영 DB에 H4 실물 415건."""
+        assert content_paras("#### 실12.1\n…\n#### 실12.10\n…") == ["실12.1", "실12.10"]
+
+    def test_conclusion_and_sme_prefixes_recognized(self):
+        """결(결론도출근거)·소(중소기업 특례) 접두 — 운영 DB에 각 107건·6건."""
+        assert content_paras("#### 결21.6\n…\n#### 소21.1\n…") == ["결21.6", "소21.1"]
+
+    def test_h5_header_recognized(self):
+        """H5 문단(ch12의 ##### 12.21~12.26 실물 6건) — 현행 채점기가 비앵커 매칭으로
+        잡고 있던 것이라, 새 규칙이 놓치면 채점 회귀가 된다."""
+        assert content_paras("##### 12.21\n인식원칙의 예외 …") == ["12.21"]
+
+    def test_h3_header_recognized(self):
+        """H3 형태(### 실2.11) — 현행 청크 정본에는 H3이 0건이지만, 빌더가 레벨을 바꿔도 추출이 깨지지 않게 포함한다."""
+        assert content_paras("### 실2.11\n…") == ["실2.11"]
+
+    def test_h6_and_body_mentions_not_matched(self):
+        """H6 제목과 본문 중간 언급은 문단 헤더가 아니다 — 잡으면 오탐."""
+        assert content_paras("###### 미주 12.1\n본문에 결21.15 또는 실15.5를 인용") == []
+
+    def test_unknown_prefix_not_matched(self):
+        """allowlist 밖 한글 접두는 미매칭 — 열린 패턴 오탐 차단이 설계 의도다."""
+        assert content_paras("#### 부록2.1\n…") == []
+
+    def test_duplicates_removed_order_kept(self):
+        assert content_paras("#### 6.13\n…\n#### 6.14\n…\n#### 6.13\n…") == ["6.13", "6.14"]
+
+    def test_three_level_number(self):
+        assert content_paras("#### 2.6.5\n…") == ["2.6.5"]
+
+
+@pytest.mark.unit
+class TestNodeIdPara:
+    """
+    node_id_para() — 단일 조항 노드는 번호가 content에 없고 chunk_id에만 있다.
+
+    운영 DB 실측: 이런 청크가 435건이고, 실2.11(TEST-K-GAAP-011의 '상계' 조항)이 정확히 이 형태다.
+    content 정규식만 고쳐서는 영구 miss로 남는다.
+    """
+
+    def test_single_clause_node_ids(self):
+        assert node_id_para("gaap-ch2-실2.11") == "실2.11"
+        assert node_id_para("gaap-ch3-결3.2") == "결3.2"
+        assert node_id_para("gaap-ch22-실22.17") == "실22.17"
+
+    def test_plain_number_tail(self):
+        assert node_id_para("gaap-ch6-6.13") == "6.13"
+
+    def test_split_suffix_stripped(self):
+        """토큰 상한 분할 뒷조각(-N 접미사)은 벗겨내고 판정한다."""
+        assert node_id_para("gaap-ch2-실2.11-2") == "실2.11"
+
+    def test_non_clause_tails_are_none(self):
+        assert node_id_para("gaap-ch6-s1-최초인식") is None
+        assert node_id_para("gaap-ch6-s1-최초인식-2") is None
+        assert node_id_para("gaap-ch10-용어의_정의-원가") is None
+        assert node_id_para("gaap-ch29-사례_4._재고자산평가손실") is None
+        assert node_id_para("gaap-ch12") is None
+        assert node_id_para("") is None
+
+
+@pytest.mark.unit
+class TestChunkParas:
+    """chunk_paras() — content 헤더 ∪ chunk_id 유니언(중복 제거)"""
+
+    def test_bundle_chunk_uses_content_headers(self):
+        assert chunk_paras("#### 6.13\n…\n#### 6.14\n…", "gaap-ch6-s1-최초인식") == ["6.13", "6.14"]
+
+    def test_single_clause_chunk_falls_back_to_id(self):
+        """실2.11 실물 재현: content에 헤더가 전혀 없어도 chunk_id에서 번호가 나온다."""
+        body = "동일 또는 유사한 거래나 회계사건에서 발생한 차익, 차손 등은 총액으로 표시하지만 …"
+        assert chunk_paras(body, "gaap-ch2-실2.11") == ["실2.11"]
+
+    def test_id_para_not_duplicated(self):
+        assert chunk_paras("#### 실2.11\n…", "gaap-ch2-실2.11") == ["실2.11"]
+
+    def test_no_number_anywhere(self):
+        assert chunk_paras("합리적인 판단력과 거래의사가 있는 …", "gaap-ch10-용어의_정의-공정가치") == []
+
+
+@pytest.mark.unit
+class TestClauseHeaderReBuilder:
+    """
+    clause_header_re() — 소비자별 변형을 한 곳에서 생성한다(사본 0).
+
+    chunker는 분할 경계로 현행 의미(H4·숫자 전용)를 고정해 소비한다.
+    경계를 넓히면 다음 재적재부터 청크 구성이 달라져 검색 회귀·벤치마크 플로어 재시드가 필요해진다.
+    """
+
+    def test_chunker_variant_h4_numeric_only(self):
+        """levels=(4,4)·prefixes=() 변형은 실·결·소와 H5를 경계로 잡지 않는다."""
+        rx = clause_header_re(levels=(4, 4), prefixes=())
+        text = "#### 2.10\n…\n#### 실2.11\n…\n##### 12.21\n…"
+        assert [m.group(1) for m in rx.finditer(text)] == ["2.10"]
+
+    def test_default_variant_is_extraction_spec(self):
+        rx = clause_header_re()
+        text = "### 실2.11\n#### 결21.6\n##### 12.21\n###### 각주"
+        assert [m.group(1) for m in rx.finditer(text)] == ["실2.11", "결21.6", "12.21"]

--- a/tests/utils/benchmark_metrics.py
+++ b/tests/utils/benchmark_metrics.py
@@ -29,6 +29,12 @@ from pathlib import Path
 from typing import Literal
 
 from pydantic import BaseModel
+from src.utils.clause_paras import (
+    NUM_CORE_PATTERN,
+    PARA_TOKEN_RE,
+    PREFIX_PATTERN,
+    chunk_paras,
+)
 from src.utils.config import KST
 from tests.utils.benchmark_loader import BenchmarkCase
 
@@ -40,29 +46,43 @@ RETRIEVAL_PASS_TOP_N = 5
 
 
 # ════════════════════════════════ 조항키 유틸 ════════════════════════════════
-# 청크 본문의 문단 헤더:  "#### 21.8", "#### 2.6.5", "#### 6.13의2"
-_CHUNK_PARA_RE = re.compile(r"####\s+(\d+\.\d+(?:\.\d+)?(?:의\d+)?)")
+# 문단번호 추출 규칙은 src/utils/clause_paras가 단일 정본
 # gold 라벨에서 장 번호:   "일반기업회계기준 제21장 …"
 _GOLD_CHAPTER_RE = re.compile(r"제\s*(\d+)\s*장")
-# 문단 토큰:               "21.8", "2.6.5", "6.13의2"
-_PARA_TOKEN_RE = re.compile(r"\d+\.\d+(?:\.\d+)?(?:의\d+)?")
-# 범위 표기:               "15.15조~15.16조"
-_RANGE_RE = re.compile(r"(\d+\.\d+(?:\.\d+)?)\s*조?\s*~\s*(\d+\.\d+(?:\.\d+)?)")
+# 문단 토큰:               "21.8", "2.6.5", "6.13의2", "실2.11" (접두 실·결·소 보존)
+_PARA_TOKEN_RE = PARA_TOKEN_RE
+# 범위 표기:               "15.15조~15.16조", "실2.46조~실2.47조"
+_RANGE_RE = re.compile(
+    rf"({PREFIX_PATTERN}?{NUM_CORE_PATTERN})\s*조?\s*~\s*({PREFIX_PATTERN}?{NUM_CORE_PATTERN})"
+)
+# 접두와 숫자 본체 분리용: "실2.46" → ("실", "2.46")
+_PREFIX_SPLIT_RE = re.compile(rf"^({PREFIX_PATTERN}?)(.+)$")
 
 
 def _normalize_para(p: str) -> str:
-    """가지번호 접미사(의N)를 제거해 기준 문단번호로 정규화한다. '21.5의2' → '21.5'."""
+    """
+    가지번호 접미사(의N)를 제거해 기준 문단번호로 정규화한다. '21.5의2' → '21.5'.
+
+    접두(실·결·소)는 키의 일부라 보존한다.
+    """
     return re.sub(r"의\d+$", "", p)
 
 
 def _expand_range(a: str, b: str) -> set[str]:
-    """'15.15'~'15.16' 처럼 같은 prefix의 연속 범위를 끝점 포함으로 펼친다."""
-    pa, pb = a.split("."), b.split(".")
-    if len(pa) == len(pb) == 2 and pa[0] == pb[0]:
+    """'
+    15.15'~'15.16' 처럼 같은 prefix의 연속 범위를 끝점 포함으로 펼친다.
+
+    '실2.46'~'실2.47'처럼 접두가 붙은 범위는 접두가 양끝에서 같을 때만 펼치고, 펼친 문단에도 접두를 유지한다(실2.46 ≠ 2.46).
+    """
+    (pre_a, num_a), (pre_b, num_b) = (
+        _PREFIX_SPLIT_RE.match(x).groups() for x in (a, b)
+    )
+    pa, pb = num_a.split("."), num_b.split(".")
+    if pre_a == pre_b and len(pa) == len(pb) == 2 and pa[0] == pb[0]:
         try:
             lo, hi = int(pa[1]), int(pb[1])
             if 0 <= hi - lo <= 50:
-                return {f"{pa[0]}.{i}" for i in range(lo, hi + 1)}
+                return {f"{pre_a}{pa[0]}.{i}" for i in range(lo, hi + 1)}
         except ValueError:
             pass
     return {a, b}
@@ -104,9 +124,13 @@ def gold_para_set(clauses: list[GoldClause]) -> set[str]:
     return s
 
 
-def extract_chunk_paras(content: str) -> set[str]:
-    """청크/인용 본문에서 문단 헤더 번호를 정규화 집합으로 추출한다."""
-    return {_normalize_para(p) for p in _CHUNK_PARA_RE.findall(content)}
+def extract_chunk_paras(content: str, chunk_id: str = "") -> set[str]:
+    """
+    청크/인용에서 문단번호를 정규화 집합으로 추출한다(content 헤더 ∪ chunk_id).
+
+    chunk_id를 함께 주면 단일 조항 노드(번호가 본문에 없고 id에만 있는 청크, 예: "gaap-ch2-실2.11")도 채점된다.
+    """
+    return {_normalize_para(p) for p in chunk_paras(content, chunk_id)}
 
 
 def _paras_match(gold_paras: set[str], cand_paras: set[str], mode: str) -> set[str]:
@@ -126,14 +150,22 @@ def _paras_match(gold_paras: set[str], cand_paras: set[str], mode: str) -> set[s
     return hits
 
 
-def rank_hit(contents: list[str], gold_paras: set[str], mode: str) -> tuple[int | None, set[str]]:
-    """순위대로 정렬된 후보 본문 리스트에서 첫 hit 순위(1-based)와 누적 커버 문단을 반환한다."""
+def rank_hit(
+    contents: list[str | tuple[str, str]], gold_paras: set[str], mode: str
+) -> tuple[int | None, set[str]]:
+    """
+    순위대로 정렬된 후보 리스트에서 첫 hit 순위(1-based)와 누적 커버 문단을 반환한다.
+
+    항목은 본문 문자열, 또는 (본문, chunk_id) 쌍이다.
+    쌍으로 주면 번호가 chunk_id에만 있는 단일 조항 청크도 hit로 인정된다. 문자열 형태는 기존 재현 하니스(scripts/*_replay.py)의 호출을 깨지 않기 위한 하위호환이다.
+    """
     first_hit: int | None = None
     covered: set[str] = set()
     if not gold_paras:
         return None, covered
-    for rank, content in enumerate(contents, start=1):
-        inter = _paras_match(gold_paras, extract_chunk_paras(content), mode)
+    for rank, item in enumerate(contents, start=1):
+        content, chunk_id = (item, "") if isinstance(item, str) else item
+        inter = _paras_match(gold_paras, extract_chunk_paras(content, chunk_id), mode)
         if inter:
             covered |= inter
             if first_hit is None:
@@ -153,9 +185,15 @@ def resolve_core_paras(case: BenchmarkCase, gold_paras: set[str]) -> set[str]:
 
 
 def retrieval_pass(
-    search_contents: list[str], core_paras: set[str], top_n: int = RETRIEVAL_PASS_TOP_N
+    search_contents: list[str | tuple[str, str]],
+    core_paras: set[str],
+    top_n: int = RETRIEVAL_PASS_TOP_N,
 ) -> bool:
-    """핵심 조항이 검색 결과 상위 top_n 안에 있으면 검색 통과(True)."""
+    """
+    핵심 조항이 검색 결과 상위 top_n 안에 있으면 검색 통과(True).
+
+    항목 형태(본문 문자열 또는 (본문, chunk_id) 쌍)는 rank_hit와 같다.
+    """
     fh, _ = rank_hit(search_contents, core_paras, "exact")
     return fh is not None and fh <= top_n
 
@@ -269,11 +307,13 @@ def measure_case(case: BenchmarkCase, k: int) -> CaseResult:
     retrieved = state.get("retrieved_chunks") or []
     citations = list(fr.citations) if fr else []
 
-    search_contents = [r.chunk.content for r in reranked]
-    cite_contents = [c.content for c in citations]
+    # (본문, chunk_id) 쌍으로 채점한다 — 단일 조항 청크(번호가 id에만 있음) 인정
+    search_items = [(r.chunk.content, r.chunk.chunk_id) for r in reranked]
+    cite_items = [(c.content, c.chunk_id) for c in citations]
+    cite_contents = [c.content for c in citations]  # 전문 영속화(diag)용
 
     metrics: dict = {}
-    for stage, contents in (("retrieval", search_contents), ("generation", cite_contents)):
+    for stage, contents in (("retrieval", search_items), ("generation", cite_items)):
         for mode in ("exact", "prefix"):
             fh, cov = rank_hit(contents, gold_paras, mode)
             metrics[f"{stage}_{mode}_hit@1"] = fh == 1
@@ -285,7 +325,7 @@ def measure_case(case: BenchmarkCase, k: int) -> CaseResult:
     metrics["legacy_substring"] = legacy_substring_hit(case.references, citations)
     metrics["is_answerable"] = bool(fr.is_answerable) if fr else False
     # 핵심(core) 조항이 검색 Top-5 안에 있으면 통과
-    metrics["retrieval_pass"] = retrieval_pass(search_contents, resolve_core_paras(case, gold_paras))
+    metrics["retrieval_pass"] = retrieval_pass(search_items, resolve_core_paras(case, gold_paras))
     res.metrics = metrics
 
     # 진단 정보(오답 분석용) + 회계사 검토·content 판정용 전문 영속화
@@ -301,7 +341,9 @@ def measure_case(case: BenchmarkCase, k: int) -> CaseResult:
         "needs_external": getattr(ev, "needs_external", None),
         "eval_reasoning": (getattr(ev, "reasoning", "") or ""),
         "retrieval_chapters": [r.chunk.metadata.chapter for r in reranked][:10],
-        "citation_paras": sorted({p for c in citations for p in extract_chunk_paras(c.content)}),
+        "citation_paras": sorted(
+            {p for c in citations for p in extract_chunk_paras(c.content, c.chunk_id)}
+        ),
         "query": case.query,
         "expected_answer": case.expected_answer,
         "answer": (fr.answer if fr else ""),


### PR DESCRIPTION
> **한 줄 요약(BLUF):** 결과 화면을 **답변 중심**으로 개편한다 — 답변 속 인용 마커(`[1]`)를 실제 조항 번호(`(18.9)`)로 바꿔 클릭하면 사이드 패널에서 원문(PDF, 미배치 시 인용 본문)을 확인한다. 그 기반으로 문단번호 추출 규칙을 `src/utils/clause_paras.py` 단일 정본으로 공용화하고(#255), 뷰어를 막던 PDF 응답 표지 결함을 고쳤다(#259).

## 커밋 흐름

| 커밋 | 이슈 | 내용 |
|---|---|---|
| `c06fce3` | #259 | PDF 서빙 표지를 `attachment`→`inline`으로 — 뷰어 빈 화면 결함 수정, 한글 파일명(RFC 5987) 경로 포함 표지 단언 테스트 추가 |
| `563b94b` | #255 | 문단번호 추출을 공용 모듈로 승격 + 실·결·소 접두 보존 + **content 헤더 ∪ chunk_id 유니언**(번호가 id에만 있는 단일 조항 노드 435건 구제) — 채점기·chunker 소비 전환, 재현 하니스 7종은 하위호환으로 무수정 |
| `b5b9b75` | #260 | `ClauseRow→ClauseOut·CitationOut`에 `paras`(문단번호 목록, 원형 보존) 노출 |
| `babca27` | #255·#260 | 굵게 표기(`**실19.1**`) 조항 번호 인식(ch19 실무지침 4건) + 조항 카드 칩·마크다운 렌더(react-markdown+remark-gfm) |
| `8d50ffe`·`0e4db05` | #260 | **답변 중심 레이아웃**: 검색 조항·인용 목록 섹션 제거, 마커→조항번호 치환(백엔드 `extract_citations_from_text`의 첫 등장 순서 규칙 복원), 인용 사이드 패널(그리드 컬럼 참여로 본문 가림 방지, PDF 미배치 시 본문 마크다운 폴백, 저작권 표기 유지) |

## 실측 근거 (운영 DB 1,507청크·33장 전수조사, 7/25)

- 접두 헤더 실물: **실 415 · 결 107 · 소 6건** → allowlist `실|결|소` 확정(열린 한글 패턴 금지)
- 번호가 chunk_id에만 있는 단일 조항 노드 **435건** — #255의 발단인 `실2.11`(TEST-K-GAAP-011)이 이 형태라, 정규식만으론 영구 miss → 유니언 채택
- 칩 커버리지: 현행 27.3% → **69.1%** (잔여 30.9%는 용어 정의·사례 등 번호가 본래 없는 콘텐츠)
- chunker 분할 경계는 **현행 의미(H4·숫자 전용) 고정** — 재적재 영향 0 (경계 확장은 별도 이슈에서 A/B)

## 검증

- 유닛: **583 passed** (신규 약 60건 포함, 실패·에러는 클린 dev와 동일 — docling extra 미설치 7건 + dev의 깨진 `benchmark.jsonl` 3건)
- 프론트: `tsc -b && vite build` · oxlint 0건
- 라이브 스모크(:8001, 운영 DB): GAAP 질의 → 조항 5건 `paras` 정상(`실7.12`는 chunk_id 폴백으로 추출), K-IFRS 필터는 미적재라 근거 부족(정상 동작)

## 리뷰 참고

- base가 dev라 `Closes`로 자동 close되지 않음 → 병합 후 **#259 수동 close**, #255·#260은 잔여(마일스톤 부착·본문 개정·실측 기록) 반영하며 처리 예정
- 이 레이아웃은 NFR-002의 UI 서열("검색 조항을 답변보다 먼저 노출", #96)과 다른 새 방향 — 데이터·채점 불변, 화면 정책만 변경이며 `clauses`는 API에 유지되어 되돌릴 수 있음. 결정 경과는 #260에 기록 예정
- 사이드 패널 너비 보정(뷰포트 clamp) 커밋 1건이 곧 추가됨

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WSmihig8sbz3RC2MvPJ6Mx
