### PR TITLE
fix: unblock tests without optional extras; report skips honestly

### DIFF
--- a/src/ingest/parse/parser.py
+++ b/src/ingest/parse/parser.py
@@ -15,10 +15,21 @@ Docling이란?
     - Docling을 감싸서(wrapping) 우리 프로젝트에 맞는 인터페이스를 제공합니다.
     - PDF에서 마크다운 텍스트와 표 데이터를 추출하여 ParsedDocument로 반환합니다.
 """
+from __future__ import annotations
+
 import html
 from pathlib import Path
+from typing import TYPE_CHECKING
+
 from src.ingest.parse.parser_dtos import ParsedDocument, _PAGE_TOP_THRESHOLD, _PAGE_BOT_THRESHOLD
-from docling.document_converter import DocumentConverter
+
+# docling은 선택 의존성이다 — `uv sync --extra ingest`로만 설치되고, 운영 이미지·기본 개발 환경에는 없다(용량이 커서 파싱을 실제로 돌리는 환경에만 넣는다).
+# 그래서 모듈 최상단이 아니라 실제로 converter를 만드는 _get_converter()에서 import한다.
+# 이렇게 해두면 파싱 스택이 없는 환경에서도 이 모듈을 import해 DoclingParser를 만들거나 table_to_text() 같은 순수 로직을 쓸 수 있다.
+# 최상단 import였을 때는 모듈을 불러오기만 해도 ModuleNotFoundError가 났다.
+# 타입 표기에 쓰는 이름은 TYPE_CHECKING 블록에서만 가져온다. 이 블록은 pyright 같은 타입 검사기만 읽고 실행 시점에는 건너뛴다.
+if TYPE_CHECKING:
+    from docling.document_converter import DocumentConverter
 
 
 class DoclingParser:
@@ -89,6 +100,7 @@ class DoclingParser:
                 )
             else:
                 # 기본 설정: Docling이 제공하는 기본 DocumentConverter 사용
+                from docling.document_converter import DocumentConverter
                 self._converter = DocumentConverter()
         return self._converter
 

--- a/src/ingest/parse/parser_dtos.py
+++ b/src/ingest/parse/parser_dtos.py
@@ -11,9 +11,20 @@ DTO란?
     2. 리스트 마커(번호 매기기 기호)를 인식하기 위한 정규표현식 패턴
     3. ParsedDocument — 파싱 결과 DTO (정본은 src/models/schemas.py, 여기서 재노출)
 """
+from __future__ import annotations
+
 import re
 from dataclasses import dataclass
-from docling_core.types.doc.document import RefItem
+from typing import TYPE_CHECKING
+
+# docling_core(파싱 라이브러리 docling의 타입 패키지)는 선택 의존성이다. 
+# `uv sync --extra ingest`로만 설치되고, 운영 이미지·기본 개발 환경에는 없다.
+# 아래 RefItem은 _ItemInfo의 필드 타입 표기에만 쓰이므로, 실행에는 필요하지 않다.
+# TYPE_CHECKING 블록은 pyright 같은 타입 검사기만 읽고 실행 시점에는 건너뛰므로, 파싱 스택이 없는 환경에서도 이 모듈을 import할 수 있다.
+# 없으면 이 모듈을 거쳐 가는 모든 코드가 ModuleNotFoundError로 죽는다.
+# 파일 첫 줄의 `from __future__ import annotations`가 모든 타입 표기를 문자열로 미뤄 주기 때문에 성립한다.
+if TYPE_CHECKING:
+    from docling_core.types.doc.document import RefItem
 
 # ParsedDocument의 단일 정본은 src/models/schemas.py. 
 # 기존 import 경로(src.ingest.parse.parser_dtos) 호환을 위해 재노출한다. 

--- a/tests/integration/ingestion/test_ingestion_pipeline.py
+++ b/tests/integration/ingestion/test_ingestion_pipeline.py
@@ -36,8 +36,23 @@ def _word_count(text: str) -> int:
 
 
 def _load_graph(chapter: str) -> OntologyGraph:
-    """data/ontology/<chapter>.json을 OntologyGraph로 역직렬화한다."""
+    """data/ontology/<chapter>.json을 OntologyGraph로 역직렬화한다.
+
+    파일이 없으면 실패시키지 않고 건너뛴다.
+    이 JSON은 저작권이 있는 기준서 원문을 온톨로지 빌더에 통과시켜 얻는 파생물이라 레포에 추적하지 않는다.
+    원자료는 각자 준비한다는 방침이고, .gitignore가 data/ontology를 제외한다.
+    그래서 레포를 새로 받은 사람에게 이 파일이 없는 것은 정상이다.
+    없다고 실패시키면 데이터 미보유가 코드 결함처럼 보여서, 진짜 결함을 찾는 시간을 빼앗는다.
+
+    갖추는 방법은 장별로 온톨로지를 빌드하는 것이다.
+    예: uv run python -m src.ingest.ontology.builder --input <원문.md> --output data/ontology/gaap-ch6.json --standard-id gaap-ch6 --standard-type GAAP
+    """
     path = ONTOLOGY_DIR / f"{chapter}.json"
+    if not path.exists():
+        pytest.skip(
+            f"온톨로지 JSON을 찾지 못했습니다: {path} — "
+            "레포에 추적되지 않는 데이터입니다. 온톨로지 빌더로 생성한 뒤 실행하면 검증됩니다"
+        )
     return OntologyGraph.model_validate_json(path.read_text(encoding="utf-8"))
 
 

--- a/tests/run_tests.py
+++ b/tests/run_tests.py
@@ -13,6 +13,12 @@
     --skip-unit       Phase 0를 건너뛰고 Phase 1부터 시작
     --durations=N     느린 테스트 N개 출력
 
+판정 읽는 법:
+    Phase마다 PASSED / NOT VERIFIED / FAILED 중 하나로 판정한다.
+    NOT VERIFIED는 "실패는 없었지만 한 건도 실행되지 않았다"는 뜻이다.
+    예를 들어 API 키나 DB가 없으면 Phase 2의 벤치마크가 전부 건너뛰어지는데,
+    이때 실패가 0건이라고 품질이 검증된 것은 아니다. 두 상태를 구분해 표시한다.
+
 Phase 구조:
     Phase 0 (Unit Test)
         개별 함수 논리를 모킹 기반으로 검증합니다. 외부 의존성 없이
@@ -33,7 +39,79 @@ Phase 구조:
 """
 import subprocess
 import sys
+import tempfile
 import time
+import xml.etree.ElementTree as ET
+from dataclasses import dataclass
+from pathlib import Path
+
+# ── Phase 판정 세 가지 ──
+#
+# 왜 "통과/실패" 두 가지로는 부족한가:
+#     pytest는 "수집은 했지만 전부 건너뛴" 경우에도 종료 코드 0을 준다.
+#     실패가 없으니 형식상 맞는 값이다.
+#     그래서 종료 코드만 보면, API 키나 DB가 없어 벤치마크 114건이 통째로 건너뛴 실행도
+#     "통과"로 보고된다. 정확도 게이트가 조용히 꺼진 채 초록불이 켜지는 것이다.
+#     실제로 그런 실행이 `✅ 전체 테스트 통과`를 출력한 사례가 있었다.
+#     그래서 "실패는 없었다"와 "검증했다"를 구분한다.
+PASSED = "passed"              # 실패 0건이고, 실제로 1건 이상 실행됐다 — 검증된 상태
+NOT_VERIFIED = "not_verified"  # 실패 0건이지만 실행 0건 — 아무것도 검증하지 못했다
+FAILED = "failed"              # 실패나 오류가 있었다
+
+_VERDICT_LABEL = {
+    PASSED: "PASSED ✅",
+    NOT_VERIFIED: "NOT VERIFIED ⚠️  (전부 건너뜀 — 검증되지 않았습니다)",
+    FAILED: "FAILED ❌",
+}
+
+
+@dataclass
+class PhaseResult:
+    """한 Phase의 판정과 실행 건수.
+
+    executed는 실제로 몸통이 돌아간 건수(건너뛴 것 제외)다.
+    이 값이 0이면 초록불이어도 검증된 것이 없다.
+    """
+    verdict: str
+    executed: int
+    skipped: int
+
+    @property
+    def blocking(self) -> bool:
+        """후속 Phase를 중단시켜야 하는 상태인가.
+
+        검증 안 됨(NOT_VERIFIED)은 중단시키지 않는다.
+        라이브 인프라가 없는 개발 환경에서는 정상적으로 일어나는 일이고,
+        여기서 멈추면 API 과금과 Docker 상시 기동을 사실상 강제하게 된다.
+        지금 필요한 것은 검증을 강제하는 게 아니라, 검증되지 않았음을 숨기지 않는 것이다.
+        """
+        return self.verdict == FAILED
+
+
+def _read_counts(report_path: Path) -> tuple[int, int] | None:
+    """pytest가 남긴 JUnit XML 리포트에서 (실행 건수, 건너뜀 건수)를 읽는다.
+
+    JUnit XML의 tests 속성은 건너뛴 것까지 포함한 총 건수라서,
+    실제로 돌아간 건수는 tests에서 skipped를 뺀 값이다.
+    예: tests=121, skipped=121 → 실행 0건, 즉 아무것도 검증하지 못한 실행이다.
+
+    화면 출력을 긁는 대신 이 파일을 읽는 이유는, 출력 문구가 pytest 버전에 따라 바뀌어도
+    이 XML의 속성 이름은 그대로이기 때문이다. 표준 라이브러리만 쓰므로 의존성도 늘지 않는다.
+    리포트를 못 읽으면 판단을 꾸며내지 않고 None을 반환한다.
+    """
+    try:
+        root = ET.parse(report_path).getroot()
+    except (OSError, ET.ParseError):
+        return None
+
+    # pytest는 <testsuites> 안에 <testsuite>를 하나 넣는다. 두 형태 모두 받아들인다.
+    suites = root.findall("testsuite") or ([root] if root.tag == "testsuite" else [])
+    if not suites:
+        return None
+
+    total = sum(int(s.get("tests", 0)) for s in suites)
+    skipped = sum(int(s.get("skipped", 0)) for s in suites)
+    return total - skipped, skipped
 
 
 def run_phase(
@@ -41,31 +119,45 @@ def run_phase(
     marker: str,
     test_path: str,
     extra_args: list[str] = None,
-) -> bool:
-    """단일 Phase를 실행하고 성공 여부를 반환한다."""
-    args = [
-        sys.executable, "-m", "pytest",
-        test_path,
-        "-m", marker,
-        "-v",
-        "--tb=short",
-    ]
-    if extra_args:
-        args.extend(extra_args)
-
+) -> PhaseResult:
+    """단일 Phase를 실행하고 판정과 실행 건수를 반환한다."""
     print(f"\n{'='*70}")
     print(f"  {phase_name}")
     print(f"  대상: {test_path}  |  marker: -m {marker}")
     print(f"{'='*70}\n")
 
-    start = time.time()
-    result = subprocess.run(args)
-    elapsed = time.time() - start
+    with tempfile.TemporaryDirectory() as tmp:
+        report_path = Path(tmp) / "report.xml"
+        args = [
+            sys.executable, "-m", "pytest",
+            test_path,
+            "-m", marker,
+            "-v",
+            "--tb=short",
+            f"--junitxml={report_path}",
+        ]
+        if extra_args:
+            args.extend(extra_args)
 
-    status = "PASSED ✅" if result.returncode == 0 else "FAILED ❌"
-    print(f"\n  {phase_name}: {status} ({elapsed:.2f}s)")
+        start = time.time()
+        completed = subprocess.run(args)
+        elapsed = time.time() - start
 
-    return result.returncode == 0
+        counts = _read_counts(report_path)
+
+    executed, skipped = counts if counts else (0, 0)
+    if completed.returncode != 0:
+        verdict = FAILED
+    elif counts is None:
+        # 실패는 없었지만 건수를 확인할 수 없다. 검증했다고 단정하지 않는다.
+        verdict = NOT_VERIFIED
+    else:
+        verdict = PASSED if executed > 0 else NOT_VERIFIED
+
+    print(f"\n  {phase_name}: {_VERDICT_LABEL[verdict]} ({elapsed:.2f}s)")
+    print(f"  실행 {executed}건 · 건너뜀 {skipped}건")
+
+    return PhaseResult(verdict=verdict, executed=executed, skipped=skipped)
 
 
 def main():
@@ -81,64 +173,84 @@ def main():
     print("  회계 RAG 시스템 — 통합 테스트")
     print("=" * 70)
 
+    # 실행한 Phase의 판정을 순서대로 모아, 마지막에 어디까지 실제로 검증됐는지 요약한다.
+    results: list[tuple[str, PhaseResult]] = []
+
     # ── Phase 0: Unit Test ──
     if not phase1_only and not phase2_only and not skip_unit:
-        phase0_ok = run_phase(
+        phase0 = run_phase(
             "Phase 0: Unit Test (함수 논리 검증)",
             "unit",
             "tests/unit/",
             extra_args,
         )
+        results.append(("Phase 0", phase0))
 
-        if not phase0_ok:
+        if phase0.blocking:
             print("\n⛔ Phase 0 실패 — 단위 테스트를 먼저 해결하십시오.")
             print("   후속 Phase는 실행하지 않습니다.")
             sys.exit(1)
 
         if phase0_only:
-            print("\n✅ Phase 0 단독 실행 완료.")
+            print_summary(results)
             sys.exit(0)
 
     # ── Phase 1: System Integration ──
     if not phase2_only:
-        phase1_ok = run_phase(
+        phase1 = run_phase(
             "Phase 1: System Integration (구조·예외 검증)",
             "system",
             "tests/integration/",
             extra_args,
         )
+        results.append(("Phase 1", phase1))
 
-        if not phase1_ok:
+        if phase1.blocking:
             print("\n⛔ Phase 1 실패 — 시스템 워크플로우 결함이 발견되었습니다.")
             print("   Phase 2(Benchmark)는 실행하지 않습니다.")
             sys.exit(1)
 
         if phase1_only:
-            print("\n✅ Phase 1 단독 실행 완료.")
+            print_summary(results)
             sys.exit(0)
 
     # ── Phase 2: Benchmark Quality ──
-    phase2_ok = run_phase(
+    phase2 = run_phase(
         "Phase 2: Benchmark Quality (비즈니스 품질 검증)",
         "benchmark",
         "tests/integration/",
         extra_args,
     )
+    results.append(("Phase 2", phase2))
 
-    if not phase2_ok:
+    if phase2.blocking:
         print("\n⚠️  Phase 2 실패 — Benchmark 품질 기준을 충족하지 못합니다.")
         sys.exit(1)
 
-    # ── 최종 결과 ──
-    phases_run = []
-    if not skip_unit and not phase1_only and not phase2_only:
-        phases_run.append("Phase 0")
-    if not phase2_only:
-        phases_run.append("Phase 1")
-    phases_run.append("Phase 2")
+    print_summary(results)
 
+
+def print_summary(results: list[tuple[str, "PhaseResult"]]) -> None:
+    """Phase별 판정을 한자리에 모아 출력한다.
+
+    실행한 Phase가 하나라도 검증되지 않았다면 "전체 통과"라고 쓰지 않는다.
+    두 상태를 같은 문장으로 뭉개면, 읽는 사람이 검증되지 않은 것을 검증됐다고 믿는다.
+    """
     print("\n" + "=" * 70)
-    print(f"  ✅ 전체 테스트 통과 ({' + '.join(phases_run)})")
+
+    not_verified = [name for name, r in results if r.verdict == NOT_VERIFIED]
+    if not_verified:
+        print("  ⚠️  일부 Phase가 검증되지 않았습니다 — 실패는 없었지만 실행 건수가 0입니다.")
+    else:
+        print("  ✅ 실행한 Phase 전부 통과")
+
+    for name, r in results:
+        print(f"     {name}: {_VERDICT_LABEL[r.verdict]}  (실행 {r.executed}건 · 건너뜀 {r.skipped}건)")
+
+    if not_verified:
+        print(f"\n  {', '.join(not_verified)}는 품질을 보증하지 않습니다.")
+        print("  라이브 인프라(DB·API 키)를 갖추고 다시 실행하면 실제로 검증됩니다.")
+
     print("=" * 70 + "\n")
 
 

--- a/tests/unit/clients/test_embedding.py
+++ b/tests/unit/clients/test_embedding.py
@@ -10,6 +10,10 @@
 
 torch/SentenceTransformer는 mock으로 차단해 실제 모델 로드 없이 논리만 검증한다.
 """
+import sys
+import types
+from contextlib import contextmanager
+
 import pytest
 from unittest.mock import patch, MagicMock
 
@@ -17,6 +21,34 @@ import numpy as np
 
 from src.utils.config import EMBEDDING_DIM, EMBEDDING_ENCODE_BATCH_SIZE
 from src.utils.exception import LLMAPIConnectionError
+
+
+@contextmanager
+def _fake_torch(*, cuda: bool, mps: bool):
+    """
+    torch 자리에, 가속기 가용성만 답하는 가짜 모듈을 끼워 넣는다.
+
+    왜 필요한가:
+        torch는 선택 의존성(optional dependency: `uv sync --extra local-embedding`으로만 설치되는 무거운 패키지)이다. 
+        기본 개발 환경·운영 이미지에는 없다.
+        그래서 실물 torch를 `patch("torch.cuda.is_available")`처럼 문자열 경로로 가리키면, patch가 대상을 찾으려 torch를 import하다 ModuleNotFoundError로 죽는다.
+        검증하려는 것은 "가용성 → 디바이스" 우선순위 논리뿐이므로, 가짜 모듈로 충분하다.
+
+    어떻게 동작하는가:
+        _resolve_device()는 함수 안에서 `import torch`를 한다(지연 임포트). import 문은
+        sys.modules를 먼저 보므로, 그 자리에 가짜를 넣어두면 실제 설치 여부와 무관하게
+        가짜가 잡힌다.
+
+    예: _fake_torch(cuda=False, mps=True) 안에서 _resolve_device("auto") → "mps"
+    """
+    fake = types.SimpleNamespace(
+        cuda=types.SimpleNamespace(is_available=lambda: cuda),
+        backends=types.SimpleNamespace(
+            mps=types.SimpleNamespace(is_available=lambda: mps),
+        ),
+    )
+    with patch.dict(sys.modules, {"torch": fake}):
+        yield
 
 
 @pytest.mark.unit
@@ -35,24 +67,21 @@ class TestResolveDevice:
         """auto: CUDA가 가용하면 cuda를 고른다 (최우선)"""
         from src.clients.embedding import _resolve_device
 
-        with patch("torch.cuda.is_available", return_value=True), \
-             patch("torch.backends.mps.is_available", return_value=True):
+        with _fake_torch(cuda=True, mps=True):
             assert _resolve_device("auto") == "cuda"
 
     def test_auto_falls_back_to_mps(self):
         """auto: CUDA가 없고 MPS만 가용하면 mps를 고른다"""
         from src.clients.embedding import _resolve_device
 
-        with patch("torch.cuda.is_available", return_value=False), \
-             patch("torch.backends.mps.is_available", return_value=True):
+        with _fake_torch(cuda=False, mps=True):
             assert _resolve_device("auto") == "mps"
 
     def test_auto_falls_back_to_cpu(self):
         """auto: 가속기가 없으면 cpu (Docker on Mac 컨테이너 경로)"""
         from src.clients.embedding import _resolve_device
 
-        with patch("torch.cuda.is_available", return_value=False), \
-             patch("torch.backends.mps.is_available", return_value=False):
+        with _fake_torch(cuda=False, mps=False):
             assert _resolve_device("auto") == "cpu"
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -4120,7 +4120,7 @@ wheels = [
 
 [[package]]
 name = "rag-for-accounting"
-version = "0.1.0"
+version = "1.0.0"
 source = { virtual = "." }
 dependencies = [
     { name = "deepagents" },


### PR DESCRIPTION
기본 `uv sync` 환경에서 `uv run tests/run_tests.py`가 Phase 0에서 멈추던 문제를 고치고, 라이브 인프라가 없을 때 러너가 "전부 건너뜀"을 "전부 통과"로 보고하던 문제를 함께 잡았다.

## 문제

기본 환경(선택 의존성 미설치)에서 단위 테스트 10건이 실패했다.

- 파서 7건 — `docling_core` 부재
- 임베딩 3건 — `torch` 부재

Phase 1은 더 나빴다. 수집(collection) 단계에서 중단되어 system 테스트 121건이 실행조차 되지 않았다.

`docling`은 `--extra ingest`, `torch`는 `--extra local-embedding`으로만 설치되는 무거운 스택이다. 이미지 슬림화 방침상 기본 환경에 없는 것이 정상이므로, 없다고 깨지는 쪽이 결함이다.

## 원인

파서 모듈 두 곳이 docling을 **타입 표기와 converter 생성에만** 쓰면서 모듈 최상단에서 import했다. 실행에 필요 없는 자리에 필수 import를 걸어둔 셈이라, 모듈을 불러오기만 해도 `ModuleNotFoundError`가 났다.

임베딩 테스트는 실물 `torch`를 문자열 경로로 patch해서, patch가 대상을 찾으려 torch를 import하다 죽었다. 검증 대상은 "가속기 가용성 → 디바이스" 우선순위 논리뿐이라 실물 torch가 필요하지 않다.

## 수정

- `parser_dtos.py` — `RefItem`을 `TYPE_CHECKING` 블록으로 이동
- `parser.py` — `DocumentConverter` import를 실제 생성 지점인 `_get_converter()` 안으로 지연
- `test_embedding.py` — 가용성만 답하는 가짜 모듈을 `sys.modules`에 주입하는 헬퍼로 교체

지연 import는 이 레포의 기존 방식과 같다. `embedding.py`가 torch에, `parse()`가 `reading_order`에 이미 쓰고 있고, 가짜 모듈 주입은 `test_reranker.py`가 `sentence_transformers`에 쓰는 방식이다. 테스트를 skip으로 덮지 않았으므로 커버리지 손실은 없다.

## 검증

| 환경 | Phase 0 | Phase 1 |
|---|---|---|
| 기본 `uv sync` | 543 passed, 2 skipped | 7 passed, 27 skipped |
| `--extra ingest --extra local-embedding` | 합산 550 passed, 29 skipped | |

extras 설치 상태에서 실제 `DocumentConverter` 생성과 커스텀 임계값 경로도 확인했다.

## 함께 처리한 것

**온톨로지 데이터 부재는 실패가 아니라 skip이다.**

`data/ontology/*.json`은 저작권이 있는 원문에서 온톨로지 빌더가 만들어 내는 파생물이라 레포에 추적하지 않는다. 그래서 레포를 새로 받은 사람에게 이 파일이 없는 것은 정상인데, 없다고 실패시키면 데이터 미보유가 코드 결함처럼 보여 진짜 결함을 찾는 시간을 빼앗는다. 무엇이 없고 어떻게 갖추는지 알려주는 메시지와 함께 건너뛴다. 데이터가 있으면 7 passed, 없으면 2 passed / 5 skipped다.

**러너가 "전부 건너뜀"과 "전부 통과"를 구분하지 못했다.**

pytest는 수집은 했지만 전부 건너뛴 실행에도 종료 코드 0을 준다. 실패가 없으니 형식상 맞는 값이다. 그래서 API 키와 DB가 없어 벤치마크 121건이 통째로 건너뛴 실행이 `✅ 전체 테스트 통과`로 보고됐다. 정확도 게이트가 조용히 꺼진 채 초록불이 켜지는 자리다.

판정을 셋으로 나눴다.

| 판정 | 조건 |
|---|---|
| PASSED | 실패 0건이고 실행 1건 이상 |
| NOT VERIFIED | 실패 0건이지만 실행 0건 |
| FAILED | 실패나 오류 있음 |

실행 건수는 pytest가 남기는 JUnit XML에서 읽는다(임시 디렉터리에 쓰고 파싱 후 폐기). 화면 출력을 긁지 않는 이유는 pytest 버전이 올라가도 XML 속성 이름은 그대로이기 때문이고, 표준 라이브러리만 써서 의존성도 늘지 않는다.

`NOT VERIFIED`는 후속 Phase를 멈추지 않고 종료 코드도 0이다. 검증을 강제하면 API 과금과 Docker 상시 기동을 모든 개발자에게 강요하게 된다. 지금 필요한 것은 검증을 강제하는 게 아니라, 검증되지 않았음을 숨기지 않는 것이다.

실제 출력:

```
  ⚠️  일부 Phase가 검증되지 않았습니다 — 실패는 없었지만 실행 건수가 0입니다.
     Phase 0: PASSED ✅  (실행 543건 · 건너뜀 2건)
     Phase 1: PASSED ✅  (실행 7건 · 건너뜀 27건)
     Phase 2: NOT VERIFIED ⚠️  (전부 건너뜀 — 검증되지 않았습니다)  (실행 0건 · 건너뜀 121건)

  Phase 2는 품질을 보증하지 않습니다.
  라이브 인프라(DB·API 키)를 갖추고 다시 실행하면 실제로 검증됩니다.
```

세 판정 모두 실측했다. FAILED는 종료 코드가 0이 아닌 경로로 확인했고, 후속 Phase를 중단시킨다.

**`uv.lock` 버전 갱신** — `pyproject.toml`이 1.0.0으로 올라갔는데 lock에는 0.1.0이 남아 있었다.

## 남은 것

Phase 2의 벤치마크는 이 PR에서 실행하지 않았다. 라이브 DB와 LLM 호출이 필요하다. 위 출력의 `NOT VERIFIED`가 그 상태를 그대로 보여준다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01TAGnXwiZoiepUnR9cn7yYP
